### PR TITLE
Réorganiser la grille selon maquette 16/9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/app.js
+++ b/app.js
@@ -1,7 +1,8 @@
-// app.js - Dashboard Hippodrome Paris-Vincennes
+// Tableau d'affichage – Hippodrome Paris-Vincennes
+
 const PROXY = "https://ratp-proxy.hippodrome-proxy42.workers.dev/?url=";
-const WEATHER_URL = "https://api.open-meteo.com/v1/forecast?latitude=48.835&longitude=2.45&current_weather=true";
-const VELIB_URL = "https://velib-metropole-opendata.smoove.pro/opendata/Velib_Metropole/station_status.json";
+const WEATHER_URL =
+  "https://api.open-meteo.com/v1/forecast?latitude=48.835&longitude=2.45&current_weather=true";
 const RSS_URL = "https://www.francetvinfo.fr/titres.rss";
 
 const STOP_IDS = {
@@ -12,399 +13,1792 @@ const STOP_IDS = {
 };
 
 const LINES = {
-  RER_A: "line:IDFM:C01742",
-  BUS_77: "line:IDFM:C02251",
-  BUS_201: "line:IDFM:C01219"
+  RER_A: { id: "C01742", navitia: "line:IDFM:C01742", label: "RER A" },
+  BUS_77: { id: "C02251", navitia: "line:IDFM:C02251", label: "Bus 77" },
+  BUS_106: { id: "C01135", navitia: "line:IDFM:C01135", label: "Bus 106" },
+  BUS_201: { id: "C01219", navitia: "line:IDFM:C01219", label: "Bus 201" }
 };
 
-const $ = (sel, root = document) => root.querySelector(sel);
+const VELIB_STATIONS = {
+  VINCENNES: "12163",
+  BREUIL: "12128"
+};
 
-let currentNews = 0;
+const WEATHER_CODES = {
+  0: "Ciel dégagé",
+  1: "Principalement clair",
+  2: "Partiellement nuageux",
+  3: "Couvert",
+  45: "Brouillard",
+  48: "Brouillard givrant",
+  51: "Bruine faible",
+  53: "Bruine",
+  55: "Bruine forte",
+  61: "Pluie faible",
+  63: "Pluie modérée",
+  65: "Pluie forte",
+  80: "Averses faibles",
+  81: "Averses modérées",
+  82: "Fortes averses",
+  95: "Orages",
+  96: "Orages grêle",
+  99: "Orages grêle"
+};
+
+const SYTADIN_URL = "https://opendata.sytadin.fr/velc/SYTR.json";
+
+const WEATHER_CLASS_MAP = [
+  { codes: [0, 1], className: "weather-sun" },
+  { codes: [2, 3], className: "weather-cloud" },
+  { codes: [45, 48], className: "weather-fog" },
+  { codes: [51, 53, 55], className: "weather-rain" },
+  { codes: [61, 63, 65, 80, 81, 82], className: "weather-rain" },
+  { codes: [95, 96, 99], className: "weather-storm" }
+];
+
+const STATUS_DEFINITIONS = {
+  normal: { label: "Affichage", priority: 5 },
+  delay: { label: "Retard", priority: 2 },
+  cancelled: { label: "Suppression", priority: 1 },
+  first: { label: "Premier service", priority: 3 },
+  last: { label: "Dernier service", priority: 3 },
+  ended: { label: "Service terminé", priority: 1 },
+  unknown: { label: "Non disponible", priority: 6 }
+};
+
+const SYTADIN_STATUS_LOOKUP = {
+  0: { text: "Fluide", className: "fluid", severity: 1 },
+  1: { text: "Dense", className: "dense", severity: 2 },
+  2: { text: "Ralentissements", className: "dense", severity: 2 },
+  3: { text: "Bouchons", className: "jam", severity: 3 },
+  4: { text: "Congestion", className: "jam", severity: 3 }
+};
+
+const SYTADIN_KEYWORDS = [
+  /a4/i,
+  /a86/i,
+  /p[ée]riph/i,
+  /porte de bercy/i,
+  /joinville/i,
+  /vincennes/i,
+  /charenton/i,
+  /maisons-alfort/i
+];
+
+const lineMetaCache = new Map();
 let newsItems = [];
-let currentInfoPanel = 0;
+let currentNews = 0;
+let coursesState = [];
 
-// --- Helpers fetch ---
-async function fetchJSON(url, timeout = 10000) {
+function decodeEntities(str = "") {
+  return str
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&apos;/gi, "'")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .trim();
+}
+
+function cleanText(str = "") {
+  return decodeEntities(str)
+    .replace(/<[^>]*>/g, " ")
+    .replace(/[<>]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+async function fetchJSON(url, timeout = 12000) {
   try {
-    const ctrl = new AbortController();
-    const id = setTimeout(() => ctrl.abort(), timeout);
-    const res = await fetch(url, { signal: ctrl.signal, cache: "no-store" });
-    clearTimeout(id);
-    if (!res.ok) throw new Error("HTTP " + res.status);
-    return await res.json();
-  } catch (e) {
-    console.error("Fetch JSON " + url + ":", e.message);
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeout);
+    const response = await fetch(url, { signal: controller.signal, cache: "no-store" });
+    clearTimeout(timer);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    return await response.json();
+  } catch (error) {
+    console.error("fetchJSON", url, error.message);
     return null;
   }
 }
 
-async function fetchText(url, timeout = 10000) {
+async function fetchText(url, timeout = 12000) {
   try {
-    const ctrl = new AbortController();
-    const id = setTimeout(() => ctrl.abort(), timeout);
-    const res = await fetch(url, { signal: ctrl.signal, cache: "no-store" });
-    clearTimeout(id);
-    if (!res.ok) throw new Error("HTTP " + res.status);
-    return await res.text();
-  } catch (e) {
-    console.error("Fetch Text " + url + ":", e.message);
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeout);
+    const response = await fetch(url, { signal: controller.signal, cache: "no-store" });
+    clearTimeout(timer);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    return await response.text();
+  } catch (error) {
+    console.error("fetchText", url, error.message);
     return null;
   }
 }
 
-// --- Rendu erreurs ---
-function renderError(el, message, type = "warning") {
-  el.innerHTML = "";
-  const div = document.createElement("div");
-  div.className = "error-message";
-  div.textContent = message;
-  el.appendChild(div);
-}
-
-// --- Divers ---
-function makeChip(text) {
-  const span = document.createElement("span");
-  span.className = "chip";
-  span.textContent = text;
-  return span;
-}
-
-function setClock() {
-  const d = new Date();
-  $("#clock").textContent = d.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
-}
-
-function setLastUpdate() {
-  const d = new Date();
-  $("#lastUpdate").textContent = "Maj " + d.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
-}
-
-// --- Parsing Transport ---
 function minutesFromISO(iso) {
   if (!iso) return null;
   return Math.max(0, Math.round((new Date(iso).getTime() - Date.now()) / 60000));
 }
 
-function parseStop(data) {
-  if (!data?.Siri?.ServiceDelivery?.StopMonitoringDelivery?.[0]?.MonitoredStopVisit) {
-    return null;
+function makeTimeChip(mainLabel, subLabel = "", options = {}) {
+  const span = document.createElement("span");
+  span.className = "time-chip";
+  if (options?.variant) {
+    span.classList.add(`time-chip--${options.variant}`);
   }
-  const visits = data.Siri.ServiceDelivery.StopMonitoringDelivery[0].MonitoredStopVisit;
-  return visits.map(v => {
-    const mv = v.MonitoredVehicleJourney || {};
-    const call = mv.MonitoredCall || {};
-    const dest = mv.DestinationName?.[0]?.value || "";
-    const stop = call.StopPointName?.[0]?.value || "";
-    const line = (mv.LineRef?.value || "").replace("STIF:Line:", "");
-    const mins = minutesFromISO(call.ExpectedDepartureTime);
-    return { line, dest, stop, minutes: mins != null ? [mins] : [] };
+
+  const main = document.createElement("span");
+  main.className = "time-chip-main";
+  main.textContent = mainLabel ?? "--";
+  span.appendChild(main);
+
+  const subs = Array.isArray(subLabel)
+    ? subLabel.filter(Boolean)
+    : subLabel
+    ? [subLabel]
+    : [];
+
+  subs.forEach(text => {
+    const sub = document.createElement("span");
+    sub.className = "time-chip-sub";
+    sub.textContent = text;
+    span.appendChild(sub);
   });
-}
 
-function groupByDest(arr) {
-  const map = {};
-  arr.forEach(x => {
-    const k = x.dest || "—";
-    map[k] = map[k] || { destination: k, minutes: [] };
-    if (x.minutes?.length) map[k].minutes.push(x.minutes[0]);
-  });
-  return Object.values(map).map(r => ({
-    ...r,
-    minutes: r.minutes.sort((a, b) => a - b).slice(0, 4)
-  }));
-}
-
-function regroupRER(data) {
-  const rows = parseStop(data);
-  if (!rows) return null;
-  return {
-    directionParis: groupByDest(rows.filter(r => /paris|la défense/i.test(r.dest))),
-    directionBoissy: groupByDest(rows.filter(r => /boissy|marne/i.test(r.dest)))
-  };
-}
-
-// --- Render Transport ---
-function renderRER(el, rows) {
-  el.innerHTML = "";
-  if (!rows || rows.length === 0) return;
-  rows.slice(0, 3).forEach(r => {
-    const row = document.createElement("div");
-    row.className = "row";
-    row.innerHTML = `<div class="dir">${r.destination}</div><div class="times"></div>`;
-    r.minutes.forEach(m => row.querySelector(".times").appendChild(makeChip(m)));
-    el.append(row);
-  });
-}
-
-function renderBus(el, buses, cls) {
-  el.innerHTML = "";
-  if (!buses || buses.length === 0) return;
-  buses.slice(0, 4).forEach(b => {
-    const row = document.createElement("div");
-    row.className = "bus-row " + cls;
-    row.innerHTML = `
-      <div class="badge">${b.line || "—"}</div>
-      <div class="dest">${b.dest}<div class="sub">${b.stop}</div></div>
-      <div class="bus-times"></div>`;
-    b.minutes.forEach(m => row.querySelector(".bus-times").appendChild(makeChip(m)));
-    el.append(row);
-  });
-}
-
-// --- Vélib ---
-// 🚲 Fonction Vélib direct avec OpenData Paris
-async function fetchVelibDirect(url, containerId) {
-  try {
-    const res = await fetch(url);
-    if (!res.ok) throw new Error("HTTP " + res.status);
-    const data = await res.json();
-
-    if (!data || !data[0]) {
-      document.getElementById(containerId).textContent = "❌ Pas de données Vélib’";
-      return;
-    }
-
-    const s = data[0]; // la station unique grâce au qv1
-    document.getElementById(containerId).innerHTML = `
-      <div class="velib-block">
-        <strong>📍 ${s.name}</strong><br>
-        🚲 ${s.mechanical} méca | 🔌 ${s.ebike} élec<br>
-        🅿️ ${s.numdocksavailable} bornes
-      </div>`;
-
-    document.getElementById('velib-update').textContent =
-      'Mise à jour : ' + (new Date()).toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'});
-  } catch (e) {
-    console.error("Erreur Vélib direct:", e);
-    document.getElementById(containerId).textContent = "❌ Erreur Vélib’";
+  if (options?.title) {
+    span.title = options.title;
   }
-}
 
-// 🚲 Boucle de mise à jour auto
-function startVelibLoop() {
-  // Appels initiaux
-  fetchVelibDirect(
-    "https://opendata.paris.fr/api/explore/v2.1/catalog/datasets/velib-disponibilite-en-temps-reel/exports/json?lang=fr&qv1=(12163)&timezone=Europe%2FParis",
-    "velib-vincennes"
-  );
-  fetchVelibDirect(
-    "https://opendata.paris.fr/api/explore/v2.1/catalog/datasets/velib-disponibilite-en-temps-reel/exports/json?lang=fr&qv1=(12128)&timezone=Europe%2FParis",
-    "velib-breuil"
-  );
-
-  // 🔄 Rafraîchissement toutes les 3 minutes
-  setInterval(() => {
-    fetchVelibDirect(
-      "https://opendata.paris.fr/api/explore/v2.1/catalog/datasets/velib-disponibilite-en-temps-reel/exports/json?lang=fr&qv1=(12163)&timezone=Europe%2FParis",
-      "velib-vincennes"
-    );
-    fetchVelibDirect(
-      "https://opendata.paris.fr/api/explore/v2.1/catalog/datasets/velib-disponibilite-en-temps-reel/exports/json?lang=fr&qv1=(12128)&timezone=Europe%2FParis",
-      "velib-breuil"
-    );
-  }, 3 * 60 * 1000); // 3 minutes
-}
-
-
-// --- Courses Vincennes ---
-async function getVincennes() {
-  const arr = [];
-  for (let d = 0; d < 3; d++) {
-    const dt = new Date();
-    dt.setDate(dt.getDate() + d);
-    const pmu = String(dt.getDate()).padStart(2, "0") + String(dt.getMonth() + 1).padStart(2, "0") + dt.getFullYear();
-    const url = PROXY + encodeURIComponent("https://offline.turfinfo.api.pmu.fr/rest/client/7/programme/" + pmu);
-    const data = await fetchJSON(url);
-    if (!data) continue;
-    data.programme.reunions.forEach(r => {
-      if (r.hippodrome.code === "VIN") {
-        r.courses.forEach(c => {
-          const hd = new Date(c.heureDepart);
-          if (hd > new Date()) {
-            arr.push({
-              heure: hd.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" }),
-              nom: c.libelle,
-              distance: c.distance,
-              discipline: c.discipline,
-              dotation: c.montantPrix,
-              ts: hd.getTime()
-            });
-          }
-        });
+  if (options?.dataset) {
+    Object.entries(options.dataset).forEach(([key, value]) => {
+      if (value != null) {
+        span.dataset[key] = value;
       }
     });
   }
-  return arr.sort((a, b) => a.ts - b.ts).slice(0, 6);
+
+  return span;
 }
 
-function renderCourses(el, courses) {
-  el.innerHTML = "";
-  if (!courses || courses.length === 0) return;
-  courses.forEach(c => {
-    const row = document.createElement("div");
-    row.className = "course-row";
-    row.innerHTML = `
-      <div class="course-time">${c.heure}</div>
-      <div class="course-info">
-        <div class="course-name">${c.nom}</div>
-        <div class="course-details">${c.distance}m • ${c.discipline}</div>
-      </div>
-      <div class="course-prize">${(c.dotation / 1000).toFixed(0)}k€</div>`;
-    el.append(row);
+function makeInfoBadge(text) {
+  const span = document.createElement("span");
+  span.className = "info-badge";
+  span.textContent = text;
+  return span;
+}
+
+function createStatusChip(tag) {
+  const span = document.createElement("span");
+  span.className = `status-chip status-${tag.type}`;
+  span.textContent = tag.label;
+  return span;
+}
+
+function trimStatusList(tags = []) {
+  if (!tags?.length) return [];
+  if (tags.length === 1 && tags[0].type === "normal") return [];
+  return tags;
+}
+
+function getStationStatusClass(tags = []) {
+  if (!tags?.length) return "ok";
+  if (tags.some(tag => tag.type === "unknown")) return "unknown";
+  if (tags.some(tag => ["delay", "cancelled", "ended"].includes(tag.type))) return "alert";
+  return "ok";
+}
+
+function formatStationSummary(tags = []) {
+  if (!tags?.length) return "Trafic normal";
+  return tags.map(tag => tag.label).join(" · ");
+}
+
+function getWeatherClass(code) {
+  const numeric = Number(code);
+  const entry = WEATHER_CLASS_MAP.find(item => item.codes.includes(numeric));
+  return entry ? entry.className : "weather-unknown";
+}
+
+function renderEmpty(container, message) {
+  if (!container) return;
+  container.innerHTML = "";
+  const empty = document.createElement("div");
+  empty.className = "empty-message";
+  empty.textContent = message;
+  container.appendChild(empty);
+}
+
+function setClock() {
+  const el = document.getElementById("clock");
+  if (!el) return;
+  const now = new Date();
+  el.textContent = now.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
+}
+
+function setLastUpdate() {
+  const el = document.getElementById("lastUpdate");
+  if (!el) return;
+  const now = new Date();
+  el.textContent = `Maj ${now.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" })}`;
+}
+
+function parseDurationSeconds(value) {
+  if (value == null) return null;
+  if (typeof value === "number") return value;
+  if (typeof value === "object") {
+    if (typeof value.value === "number") return value.value;
+    if (typeof value.seconds === "number") return value.seconds;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    const numeric = Number(trimmed.replace(",", "."));
+    if (!Number.isNaN(numeric)) return numeric;
+    const isoMatch = trimmed.match(/(-)?P(T)?(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/i);
+    if (isoMatch) {
+      const sign = isoMatch[1] ? -1 : 1;
+      const hours = Number(isoMatch[3] || 0);
+      const minutes = Number(isoMatch[4] || 0);
+      const seconds = Number(isoMatch[5] || 0);
+      return sign * ((hours * 3600) + (minutes * 60) + seconds);
+    }
+  }
+  return null;
+}
+
+function createStatusTag(type, label, value) {
+  const def = STATUS_DEFINITIONS[type] || STATUS_DEFINITIONS.unknown;
+  return {
+    type,
+    label: label || def.label,
+    priority: def.priority,
+    value: value ?? null
+  };
+}
+
+function getVisitStatusTags(visit) {
+  const map = new Map();
+  const register = tag => {
+    const existing = map.get(tag.type);
+    if (!existing || (tag.type === "delay" && (tag.value || 0) > (existing.value || 0))) {
+      map.set(tag.type, tag);
+    }
+  };
+
+  const rawStatus = `${visit.departureStatus || ""} ${visit.arrivalStatus || ""} ${visit.progressStatus || ""}`
+    .toLowerCase();
+  const noteStatus = (visit.notes || "").toLowerCase();
+  const firstLast = (visit.firstLast || "").toLowerCase();
+
+  if (/cancel|supprim|annul/.test(rawStatus) || /supprim|annul/.test(noteStatus)) {
+    register(createStatusTag("cancelled"));
+  }
+
+  if (/notexpected|no service|termin|terminé|fin de service|closed/.test(rawStatus) || /termin/.test(noteStatus)) {
+    register(createStatusTag("ended"));
+  }
+
+  if (firstLast.includes("first")) {
+    register(createStatusTag("first"));
+  }
+
+  if (firstLast.includes("last")) {
+    register(createStatusTag("last"));
+  }
+
+  if (typeof visit.delayMinutes === "number" && visit.delayMinutes > 0) {
+    register(createStatusTag("delay", `Retard +${visit.delayMinutes} min`, visit.delayMinutes));
+  }
+
+  if (!visit.minutes?.length) {
+    register(createStatusTag("unknown"));
+  }
+
+  if (!map.size) {
+    register(createStatusTag("normal"));
+  }
+
+  return Array.from(map.values());
+}
+
+function summariseStatusTags(visits = []) {
+  const summary = new Map();
+  visits.forEach(visit => {
+    const tags = getVisitStatusTags(visit);
+    visit.statusTags = tags;
+    tags.forEach(tag => {
+      const current = summary.get(tag.type);
+      if (!current || (tag.type === "delay" && (tag.value || 0) > (current.value || 0))) {
+        summary.set(tag.type, { ...tag });
+      }
+    });
+  });
+
+  let tags = Array.from(summary.values());
+  tags.sort((a, b) => a.priority - b.priority);
+  if (tags.length > 1) {
+    tags = tags.filter(tag => tag.type !== "normal");
+  }
+  return tags;
+}
+
+function formatClockTime(iso) {
+  if (!iso) return null;
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
+}
+
+function formatDepartureLabel(minutes, iso) {
+  if (minutes == null) return "--";
+  if (minutes === 0) return "À quai";
+  const safeMinutes = Math.max(0, minutes);
+  const timeLabel = formatClockTime(iso);
+  if (safeMinutes > 30 && timeLabel) {
+    return `${timeLabel} (${safeMinutes} min)`;
+  }
+  return `${safeMinutes} min`;
+}
+
+function buildDeparturesFromVisits(visits = []) {
+  return visits
+    .map(v => {
+      const rawMinutes = Array.isArray(v.minutes) ? v.minutes[0] : v.minutes;
+      if (typeof rawMinutes !== "number") return null;
+      return {
+        minutes: Math.max(0, rawMinutes),
+        expected: v.expected,
+        aimed: v.aimed
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.minutes - b.minutes)
+    .slice(0, 3);
+}
+
+function createDepartureChip(departure) {
+  const hasMinutes = Number.isFinite(departure?.minutes);
+  const minutes = hasMinutes ? Math.max(0, departure.minutes) : null;
+  const iso = departure?.expected || departure?.aimed || null;
+  const timeLabel = iso ? formatClockTime(iso) : null;
+  const tooltip = hasMinutes ? formatDepartureLabel(minutes, iso) : null;
+  const dataset = timeLabel ? { time: timeLabel } : undefined;
+
+  if (minutes == null) {
+    return makeTimeChip("--", "", {
+      variant: "unknown",
+      title: tooltip || "Horaire indisponible",
+      dataset
+    });
+  }
+
+  if (minutes === 0) {
+    return makeTimeChip("À quai", timeLabel || "", {
+      variant: "now",
+      title: tooltip || "Départ imminent",
+      dataset
+    });
+  }
+
+  if (minutes > 30) {
+    if (timeLabel) {
+      return makeTimeChip(timeLabel, `${minutes} min`, {
+        variant: "long",
+        title: tooltip || undefined,
+        dataset
+      });
+    }
+
+    return makeTimeChip(String(minutes), "min", {
+      variant: "long",
+      title: tooltip || undefined
+    });
+  }
+
+  const variant = minutes <= 5 ? "soon" : "regular";
+  const subParts = ["min"];
+  if (timeLabel) {
+    subParts.push(timeLabel);
+  }
+
+  return makeTimeChip(String(minutes), subParts.join(" · "), {
+    variant,
+    title: tooltip || undefined,
+    dataset
   });
 }
 
-// --- News ---
-function renderNews(items) {
-  newsItems = items; 
-  currentNews = 0;
-  const el = $("#news-content"); 
-  el.innerHTML = "";
-  if (!items || items.length === 0) {
-    renderError(el, "📰 Actualités indisponibles");
-    $("#news-counter").textContent = "0/0";
+function createMinutesChip(minutes) {
+  if (!Number.isFinite(minutes)) {
+    return makeTimeChip("--", "", { variant: "unknown", title: "Horaire indisponible" });
+  }
+
+  const safeMinutes = Math.max(0, minutes);
+  const approxIso = new Date(Date.now() + safeMinutes * 60000).toISOString();
+  return createDepartureChip({ minutes: safeMinutes, expected: approxIso });
+}
+
+function stopPriority(name = "") {
+  const value = name.toLowerCase();
+  if (value.includes("hippodrome")) return 0;
+  if (value.includes("joinville")) return 1;
+  if (value.includes("pyramide") || value.includes("breuil")) return 2;
+  if (value.includes("polangis")) return 3;
+  return 10;
+}
+
+function groupVisitsByStop(visits = []) {
+  const stops = new Map();
+
+  const filteredVisits = (visits || []).filter(visit => {
+    const id = visit.lineId || "";
+    const ref = visit.lineRef || "";
+    return id !== LINES.RER_A.id && !ref.includes(LINES.RER_A.id);
+  });
+
+  filteredVisits.forEach(visit => {
+    const stopName = visit.stop || "Arrêt";
+    const key = `${visit.stopId || ""}|${stopName.toLowerCase()}`;
+    if (!stops.has(key)) {
+      stops.set(key, {
+        id: visit.stopId || null,
+        name: stopName,
+        visits: [],
+        lines: new Map()
+      });
+    }
+
+    const stopEntry = stops.get(key);
+    stopEntry.visits.push(visit);
+
+    const lineKey = visit.lineId || visit.lineRef || visit.display || stopName;
+    if (!stopEntry.lines.has(lineKey)) {
+      stopEntry.lines.set(lineKey, {
+        lineId: visit.lineId,
+        lineRef: visit.lineRef,
+        visits: [],
+        destinations: new Map()
+      });
+    }
+
+    const lineEntry = stopEntry.lines.get(lineKey);
+    lineEntry.visits.push(visit);
+
+    const destKey = (visit.display || visit.fullDestination || visit.direction || "").toLowerCase();
+    if (!lineEntry.destinations.has(destKey)) {
+      lineEntry.destinations.set(destKey, {
+        display: visit.display || visit.fullDestination || "Destination à préciser",
+        fullDestination: visit.fullDestination,
+        direction: visit.direction,
+        visits: []
+      });
+    }
+
+    lineEntry.destinations.get(destKey).visits.push(visit);
+  });
+
+  return Array.from(stops.values()).map(stopEntry => {
+    const lines = Array.from(stopEntry.lines.values())
+      .map(lineEntry => {
+        const destinations = Array.from(lineEntry.destinations.values())
+          .map(destEntry => ({
+            display: destEntry.display,
+            fullDestination: destEntry.fullDestination,
+            direction: destEntry.direction,
+            departures: buildDeparturesFromVisits(destEntry.visits),
+            statusSummary: summariseStatusTags(destEntry.visits)
+          }))
+          .filter(dest => dest.departures.length || dest.statusSummary.length)
+          .sort((a, b) => (a.display || "").localeCompare(b.display || "", "fr", { numeric: true }));
+
+        return {
+          lineId: lineEntry.lineId,
+          lineRef: lineEntry.lineRef,
+          statusSummary: summariseStatusTags(lineEntry.visits),
+          destinations
+        };
+      })
+      .filter(line => line.destinations.length);
+
+    return {
+      id: stopEntry.id,
+      name: stopEntry.name,
+      statusSummary: summariseStatusTags(stopEntry.visits),
+      lines
+    };
+  });
+}
+
+function parseStop(data) {
+  const visits = data?.Siri?.ServiceDelivery?.StopMonitoringDelivery?.[0]?.MonitoredStopVisit;
+  if (!Array.isArray(visits)) return [];
+
+  return visits.map(visit => {
+    const mv = visit.MonitoredVehicleJourney || {};
+    const call = mv.MonitoredCall || {};
+    const lineRef = mv.LineRef?.value || "";
+    const lineId = lineRef.match(/C\d{5}/)?.[0] || null;
+    const destDisplay = cleanText(call.DestinationDisplay?.[0]?.value || "");
+    const destName = cleanText(mv.DestinationName?.[0]?.value || "");
+    const destShort = cleanText(mv.DestinationShortName?.[0]?.value || "");
+    const direction = cleanText(mv.DirectionName?.[0]?.value || "");
+    const stopName = cleanText(call.StopPointName?.[0]?.value || "");
+    const stopId = (call.StopPointRef?.value || call.StopPointRef || "").toString();
+    const minutes = minutesFromISO(call.ExpectedDepartureTime);
+    const departureStatus = (call.DepartureStatus?.value || call.DepartureStatus || "").toString();
+    const arrivalStatus = (call.ArrivalStatus?.value || call.ArrivalStatus || "").toString();
+    const progressStatus = Array.isArray(mv.ProgressStatus)
+      ? mv.ProgressStatus.map(item => (item?.value || item || "")).join(" ")
+      : (mv.ProgressStatus?.value || mv.ProgressStatus || "");
+    const firstLast = (call.Extensions?.FirstOrLastJourney || mv.Extensions?.FirstOrLastJourney || "").toString();
+    const notes = call.Extensions?.CallNote || call.Extensions?.Note || "";
+    const delaySeconds =
+      parseDurationSeconds(mv.Delay) ||
+      parseDurationSeconds(call.DepartureDelay) ||
+      parseDurationSeconds(call.ArrivalDelay) ||
+      parseDurationSeconds(call.Extensions?.Delay);
+
+    return {
+      lineId,
+      lineRef,
+      display: destDisplay || destShort || destName,
+      fullDestination: destName,
+      direction,
+      stop: stopName,
+      stopId,
+      minutes: minutes != null ? [minutes] : [],
+      expected: call.ExpectedDepartureTime,
+      aimed: call.AimedDepartureTime || call.AimedArrivalTime,
+      departureStatus,
+      arrivalStatus,
+      progressStatus,
+      firstLast,
+      notes,
+      delayMinutes: delaySeconds != null ? Math.round(delaySeconds / 60) : null
+    };
+  });
+}
+
+function groupByLineDestination(visits = []) {
+  const map = new Map();
+
+  visits.forEach(v => {
+    const key = `${v.lineId || v.lineRef}|${(v.display || "").toLowerCase()}`;
+    if (!map.has(key)) {
+      map.set(key, {
+        lineId: v.lineId,
+        lineRef: v.lineRef,
+        display: v.display || "Destination à préciser",
+        fullDestination: v.fullDestination,
+        direction: v.direction,
+        visits: [],
+        stops: new Map()
+      });
+    }
+    const entry = map.get(key);
+    entry.visits.push(v);
+    if (!entry.fullDestination && v.fullDestination) entry.fullDestination = v.fullDestination;
+    if (!entry.direction && v.direction) entry.direction = v.direction;
+    if (v.stop) {
+      if (!entry.stops.has(v.stop)) {
+        entry.stops.set(v.stop, { id: v.stopId || null, visits: [] });
+      }
+      entry.stops.get(v.stop).visits.push(v);
+    }
+  });
+
+  return Array.from(map.values()).map(entry => {
+    const departures = buildDeparturesFromVisits(entry.visits);
+
+    const stops = Array.from(entry.stops.entries()).map(([name, stopData]) => {
+      const stopDepartures = buildDeparturesFromVisits(stopData.visits);
+      return {
+        name,
+        id: stopData.id,
+        departures: stopDepartures,
+        minutes: stopDepartures.map(dep => dep.minutes),
+        statuses: summariseStatusTags(stopData.visits)
+      };
+    });
+
+    return {
+      lineId: entry.lineId,
+      lineRef: entry.lineRef,
+      display: entry.display,
+      fullDestination: entry.fullDestination,
+      direction: entry.direction,
+      minutes: departures.map(dep => dep.minutes),
+      departures,
+      statusSummary: summariseStatusTags(entry.visits),
+      stops
+    };
+  });
+}
+
+function normaliseColor(hex) {
+  if (!hex) return null;
+  const clean = hex.toString().trim().replace(/^#/, "");
+  if (/^[0-9a-fA-F]{6}$/.test(clean)) {
+    return `#${clean}`;
+  }
+  return null;
+}
+
+function fallbackLineMeta(lineId) {
+  return {
+    id: lineId,
+    code: lineId || "—",
+    name: "",
+    color: "#2450a4",
+    textColor: "#ffffff"
+  };
+}
+
+async function fetchLineMetadata(lineId) {
+  if (!lineId) return fallbackLineMeta(lineId);
+  if (lineMetaCache.has(lineId)) return lineMetaCache.get(lineId);
+
+  const url =
+    "https://data.iledefrance-mobilites.fr/api/explore/v2.1/catalog/datasets/referentiel-des-lignes/records?where=id_line%3D%22" +
+    lineId +
+    "%22&limit=1";
+
+  const data = await fetchJSON(url, 10000);
+  let meta = fallbackLineMeta(lineId);
+
+  if (data?.results?.length) {
+    const entry = data.results[0];
+    meta = {
+      id: lineId,
+      code: entry.shortname_line || entry.name_line || lineId,
+      name: entry.name_line || "",
+      color: normaliseColor(entry.colourweb_hexa) || "#0055c8",
+      textColor: normaliseColor(entry.textcolourweb_hexa) || "#ffffff"
+    };
+  }
+
+  lineMetaCache.set(lineId, meta);
+  return meta;
+}
+
+async function ensureLineMetas(groups) {
+  const ids = [...new Set(groups.map(g => g.lineId).filter(Boolean))];
+  const missing = ids.filter(id => !lineMetaCache.has(id));
+  if (!missing.length) return;
+  await Promise.all(missing.map(id => fetchLineMetadata(id)));
+}
+
+function renderRerDirection(container, groups, emptyMessage = "Aucune donnée en temps réel.") {
+  if (!container) return;
+  container.innerHTML = "";
+
+  if (!groups?.length) {
+    container.appendChild(makeInfoBadge(emptyMessage));
     return;
   }
-  items.forEach((n, i) => {
-    const d = document.createElement("div");
-    d.className = "news-item" + (i === 0 ? " active" : "");
-    d.innerHTML = `<div class="news-title">${n.title}</div><div class="news-text">${n.description}</div><div class="news-meta">France Info</div>`;
-    el.append(d);
+
+  groups.slice(0, 4).forEach(group => {
+    const row = document.createElement("div");
+    row.className = "rer-row";
+
+    const dest = document.createElement("div");
+    dest.className = "rer-destination";
+    dest.textContent = group.display || "Destination à préciser";
+
+    const statuses = trimStatusList(group.statusSummary);
+    const statusWrap = document.createElement("div");
+    statusWrap.className = "rer-status";
+    statuses.forEach(tag => statusWrap.appendChild(createStatusChip(tag)));
+
+    const times = document.createElement("div");
+    times.className = "rer-times";
+    const departures = Array.isArray(group.departures) ? group.departures : [];
+    if (departures.length) {
+      departures.forEach(dep => {
+        times.appendChild(createDepartureChip(dep));
+      });
+    } else if (group.minutes?.length) {
+      group.minutes.forEach(min => {
+        times.appendChild(createMinutesChip(min));
+      });
+    } else {
+      times.appendChild(makeInfoBadge("--"));
+    }
+
+    row.appendChild(dest);
+    if (statuses.length) {
+      row.appendChild(statusWrap);
+    }
+    row.appendChild(times);
+    container.appendChild(row);
   });
-  $("#news-counter").textContent = "1/" + items.length;
+}
+
+function classifyRerDestinations(visits = []) {
+  const parisRegex = /(paris|la défense|nanterre|poissy|cergy|houilles|sartrouville|etoile|nation|haussmann)/i;
+  const boissyRegex = /(boissy|marne|val d'europe|torcy|noisiel|bussy|chessy|noisy|fontenay|bry|champigny)/i;
+
+  const paris = [];
+  const boissy = [];
+  const other = [];
+
+  visits.forEach(v => {
+    const label = `${v.display} ${v.fullDestination} ${v.direction}`.toLowerCase();
+    if (parisRegex.test(label)) paris.push(v);
+    else if (boissyRegex.test(label)) boissy.push(v);
+    else other.push(v);
+  });
+
+  return {
+    paris: groupByLineDestination(paris),
+    boissy: groupByLineDestination(boissy),
+    other: groupByLineDestination(other)
+  };
+}
+
+function renderRerBlock(visits, trafficItem) {
+  const parisEl = document.getElementById("rer-paris");
+  const boissyEl = document.getElementById("rer-boissy");
+  const otherEl = document.getElementById("rer-other");
+
+  const rerVisits = (visits || []).filter(v => v.lineId === LINES.RER_A.id);
+  let { paris, boissy, other } = classifyRerDestinations(rerVisits);
+
+  if (!paris.length && other.length) {
+    paris = other;
+    other = [];
+  }
+
+  if (!boissy.length && other.length) {
+    boissy = other;
+    other = [];
+  }
+
+  renderRerDirection(parisEl, paris);
+  renderRerDirection(boissyEl, boissy);
+  renderRerDirection(otherEl, other, "Aucune autre destination pour le moment.");
+
+  updateLineAlert(document.getElementById("traffic-rer-line"), trafficItem);
+  updateStationStatus("rer-station-info", "Joinville-le-Pont", trafficItem);
+}
+
+function normaliseKey(str = "") {
+  if (!str) return "";
+  let value = str.toString();
+  if (typeof value.normalize === "function") {
+    value = value.normalize("NFD");
+  }
+  value = value.replace(/[\u0300-\u036f]/g, "");
+  return value.toLowerCase();
+}
+
+function findStationTrafficMatch(stationName, trafficMap = {}) {
+  const key = normaliseKey(stationName);
+  if (!key) return null;
+  for (const item of Object.values(trafficMap)) {
+    if (!item) continue;
+    const messages = Array.isArray(item.messages) ? item.messages : [];
+    const match = messages.find(message => normaliseKey(message).includes(key));
+    if (match) {
+      return { item, message: match };
+    }
+  }
+  return null;
+}
+
+function deriveStationSummary(stop, statuses, trafficMap) {
+  let text = formatStationSummary(statuses);
+  let className = getStationStatusClass(statuses);
+  const stationMatch = findStationTrafficMatch(stop.name, trafficMap);
+  if (stationMatch) {
+    const { item, message } = stationMatch;
+    text = message;
+    className = item.status === "alert" ? "alert" : item.status === "unknown" ? "unknown" : "ok";
+  } else {
+    const items = Object.values(trafficMap || {});
+    const alertItem = items.find(entry => entry?.status === "alert");
+    const unknownItem = items.find(entry => entry?.status === "unknown");
+    if ((!statuses.length || className === "ok") && alertItem) {
+      text = alertItem.message || `Perturbations sur ${alertItem.label || "la ligne"}.`;
+      className = "alert";
+    } else if (!statuses.length && unknownItem) {
+      text =
+        unknownItem.message || `Information trafic indisponible sur ${unknownItem.label || "la ligne"}.`;
+      className = "unknown";
+    }
+  }
+  if (!text) {
+    text = "Trafic normal";
+    className = "ok";
+  }
+  return { text, className };
+}
+
+function buildBusSummary(processedStops, trafficMap) {
+  if (!processedStops.length) {
+    return { text: "Données bus indisponibles pour le moment.", className: "unknown" };
+  }
+
+  const items = Object.values(trafficMap || {});
+  const alertItem = items.find(entry => entry?.status === "alert");
+  if (alertItem) {
+    return {
+      text: alertItem.message || `Perturbations sur ${alertItem.label || "la ligne"}.`,
+      className: "alert"
+    };
+  }
+
+  const hasSevere = processedStops.some(({ statuses }) =>
+    statuses.some(tag => ["delay", "cancelled", "ended"].includes(tag.type))
+  );
+  if (hasSevere) {
+    return { text: "Perturbations sur certaines stations.", className: "alert" };
+  }
+
+  const unknownItem = items.find(entry => entry?.status === "unknown");
+  const hasUnknown = processedStops.some(({ statuses }) => statuses.some(tag => tag.type === "unknown"));
+  if (unknownItem || hasUnknown) {
+    return {
+      text: unknownItem?.message || "Temps réel partiel sur certaines stations.",
+      className: "unknown"
+    };
+  }
+
+  const count = processedStops.length;
+  return {
+    text: `${count} station${count > 1 ? "s" : ""} suivie${count > 1 ? "s" : ""}`,
+    className: "ok"
+  };
+}
+
+function renderBusTrafficHeader(container, trafficMap = {}) {
+  if (!container) return;
+  container.innerHTML = "";
+  const lines = [LINES.BUS_77, LINES.BUS_106, LINES.BUS_201];
+  lines.forEach(line => {
+    const row = document.createElement("div");
+    row.className = "bus-traffic-row";
+    const meta = lineMetaCache.get(line.id) || fallbackLineMeta(line.id);
+
+    const badge = document.createElement("span");
+    badge.className = "line-pill";
+    badge.textContent = meta.code || meta.id || line.label;
+    badge.style.setProperty("--line-color", meta.color);
+    badge.style.setProperty("--line-text", meta.textColor);
+
+    const trafficItem = trafficMap[line.id];
+    const status = trafficItem?.status || "unknown";
+    const text = document.createElement("span");
+    text.className = `line-alert-text ${status}`;
+    let message = trafficItem?.message;
+    if (!message) {
+      if (status === "alert") {
+        message = `Perturbations sur ${trafficItem?.label || meta.code || meta.id || line.label}.`;
+      } else if (status === "ok") {
+        message = "Trafic normal";
+      } else {
+        message = "Information trafic indisponible";
+      }
+    }
+    text.textContent = message;
+
+    row.appendChild(badge);
+    row.appendChild(text);
+    container.appendChild(row);
+  });
+
+  if (!container.children.length) {
+    container.appendChild(makeInfoBadge("Information trafic indisponible"));
+  }
+}
+
+async function renderBusBoard(visits, trafficMap = {}) {
+  const container = document.getElementById("bus-stations");
+  const summaryEl = document.getElementById("bus-summary");
+  const trafficEl = document.getElementById("bus-traffic");
+  if (!container) return;
+
+  container.innerHTML = "";
+
+  const stops = groupVisitsByStop(visits || []).filter(stop => stop.lines.length);
+
+  const busTrafficIds = [LINES.BUS_77.id, LINES.BUS_106.id, LINES.BUS_201.id];
+  const busTrafficMap = busTrafficIds.reduce((acc, id) => {
+    acc[id] = trafficMap?.[id] || null;
+    return acc;
+  }, {});
+
+  const lineGroups = [
+    { lineId: LINES.BUS_77.id },
+    { lineId: LINES.BUS_106.id },
+    { lineId: LINES.BUS_201.id },
+    ...stops.flatMap(stop => stop.lines)
+  ];
+  await ensureLineMetas(lineGroups);
+
+  renderBusTrafficHeader(trafficEl, busTrafficMap);
+
+  if (!stops.length) {
+    if (summaryEl) {
+      summaryEl.textContent = "Données bus indisponibles pour le moment.";
+      summaryEl.className = "block-sub bus-summary unknown";
+    }
+    container.appendChild(makeInfoBadge("Aucun passage en temps réel pour l'instant."));
+    return;
+  }
+
+  const processedStops = stops
+    .slice()
+    .sort((a, b) => {
+      const priority = stopPriority(a.name) - stopPriority(b.name);
+      if (priority !== 0) return priority;
+      return (a.name || "").localeCompare(b.name || "", "fr", { numeric: true });
+    })
+    .map(stop => ({ stop, statuses: trimStatusList(stop.statusSummary) }));
+
+  if (summaryEl) {
+    const summaryInfo = buildBusSummary(processedStops, busTrafficMap);
+    summaryEl.textContent = summaryInfo.text;
+    summaryEl.className = `block-sub bus-summary ${summaryInfo.className}`;
+  }
+
+  processedStops.forEach(({ stop, statuses }) => {
+    const card = document.createElement("article");
+    card.className = "bus-station-card";
+    card.setAttribute("role", "listitem");
+    card.setAttribute("aria-label", `Station ${stop.name || "bus"}`);
+
+    const header = document.createElement("div");
+    header.className = "bus-station-header";
+
+    const heading = document.createElement("div");
+    heading.className = "bus-station-heading";
+
+    const title = document.createElement("h3");
+    title.className = "bus-station-title";
+    title.textContent = stop.name || "Station";
+    heading.appendChild(title);
+
+    const stationSummary = deriveStationSummary(stop, statuses, busTrafficMap);
+    const summary = document.createElement("p");
+    summary.className = `bus-station-summary ${stationSummary.className}`;
+    summary.textContent = stationSummary.text;
+    heading.appendChild(summary);
+
+    header.appendChild(heading);
+
+    if (statuses.length) {
+      const statusWrap = document.createElement("div");
+      statusWrap.className = "status-group bus-station-status";
+      statuses.forEach(tag => statusWrap.appendChild(createStatusChip(tag)));
+      header.appendChild(statusWrap);
+    }
+
+    card.appendChild(header);
+
+    const linesWrap = document.createElement("div");
+    linesWrap.className = "bus-lines";
+
+    const sortedLines = stop.lines
+      .slice()
+      .sort((a, b) => {
+        const idA = a.lineId || a.lineRef;
+        const idB = b.lineId || b.lineRef;
+        const metaA = a.lineId ? lineMetaCache.get(a.lineId) || fallbackLineMeta(idA) : fallbackLineMeta(idA);
+        const metaB = b.lineId ? lineMetaCache.get(b.lineId) || fallbackLineMeta(idB) : fallbackLineMeta(idB);
+        return (metaA.code || idA || "").localeCompare(metaB.code || idB || "", "fr", { numeric: true });
+      });
+
+    if (!sortedLines.length) {
+      linesWrap.appendChild(makeInfoBadge("Pas de passage suivi pour le moment."));
+    }
+
+    sortedLines.forEach(line => {
+      const metaId = line.lineId || line.lineRef;
+      const meta = line.lineId ? lineMetaCache.get(line.lineId) || fallbackLineMeta(metaId) : fallbackLineMeta(metaId);
+      const lineCard = document.createElement("article");
+      lineCard.className = "bus-line-card";
+
+      const lineHeader = document.createElement("div");
+      lineHeader.className = "bus-line-header";
+
+      const badge = document.createElement("span");
+      badge.className = "line-pill";
+      badge.textContent = meta.code || meta.id || line.lineRef || "—";
+      badge.style.setProperty("--line-color", meta.color);
+      badge.style.setProperty("--line-text", meta.textColor);
+
+      const trafficWrap = document.createElement("div");
+      trafficWrap.className = "bus-line-traffic";
+      const trafficKey = line.lineId || line.lineRef;
+      const trafficItem = busTrafficMap[trafficKey];
+      const trafficStatus = trafficItem?.status || "unknown";
+      const trafficText = document.createElement("span");
+      trafficText.className = `line-alert-text ${trafficStatus}`;
+      trafficText.textContent =
+        trafficItem?.message ||
+        (trafficStatus === "alert"
+          ? `Perturbations sur ${trafficItem?.label || badge.textContent}.`
+          : trafficStatus === "ok"
+          ? "Trafic normal"
+          : "Information trafic indisponible");
+      trafficWrap.appendChild(trafficText);
+
+      lineHeader.appendChild(badge);
+      lineHeader.appendChild(trafficWrap);
+      lineCard.appendChild(lineHeader);
+
+      const lineStatuses = trimStatusList(line.statusSummary);
+      if (lineStatuses.length) {
+        const statusWrap = document.createElement("div");
+        statusWrap.className = "status-group";
+        lineStatuses.forEach(tag => statusWrap.appendChild(createStatusChip(tag)));
+        lineCard.appendChild(statusWrap);
+      }
+
+      const destinationsWrap = document.createElement("div");
+      destinationsWrap.className = "bus-destinations";
+
+      line.destinations.forEach(dest => {
+        const row = document.createElement("div");
+        row.className = "bus-destination-row";
+
+        const info = document.createElement("div");
+        info.className = "bus-destination-info";
+
+        const destName = document.createElement("span");
+        destName.className = "destination-name";
+        destName.textContent = dest.display || dest.fullDestination || "Destination à préciser";
+        info.appendChild(destName);
+
+        const destStatuses = trimStatusList(dest.statusSummary);
+        if (destStatuses.length) {
+          const statusGroup = document.createElement("div");
+          statusGroup.className = "status-group";
+          destStatuses.forEach(tag => statusGroup.appendChild(createStatusChip(tag)));
+          info.appendChild(statusGroup);
+        }
+
+        row.appendChild(info);
+
+        const times = document.createElement("div");
+        times.className = "bus-times";
+        if (dest.departures.length) {
+          dest.departures.forEach(dep => times.appendChild(createDepartureChip(dep)));
+        } else {
+          times.appendChild(makeInfoBadge("--"));
+        }
+
+        row.appendChild(times);
+        destinationsWrap.appendChild(row);
+      });
+
+      lineCard.appendChild(destinationsWrap);
+      linesWrap.appendChild(lineCard);
+    });
+
+    card.appendChild(linesWrap);
+    container.appendChild(card);
+  });
+}
+
+function formatLineLabel(meta, fallback) {
+  if (!meta) return fallback;
+  if (meta.name) return meta.name;
+  if (meta.code) return `${fallback.split(" ")[0]} ${meta.code}`;
+  return fallback;
+}
+
+async function buildTrafficItem(line, messages) {
+  const meta = await fetchLineMetadata(line.id);
+  let status = "ok";
+  let message = "Trafic normal";
+  const cleanedMessages = Array.isArray(messages)
+    ? messages.map(m => cleanText(m)).filter(Boolean)
+    : [];
+
+  if (messages === null) {
+    status = "unknown";
+    message = "Information trafic indisponible";
+  } else if (cleanedMessages.length) {
+    status = "alert";
+    message = cleanedMessages[0];
+  }
+
+  return {
+    id: line.id,
+    code: meta.code,
+    label: formatLineLabel(meta, line.label),
+    color: meta.color,
+    textColor: meta.textColor,
+    status,
+    message,
+    messages: cleanedMessages
+  };
+}
+
+function updateLineAlert(container, item) {
+  if (!container) return;
+  container.innerHTML = "";
+  if (!item) {
+    container.appendChild(makeInfoBadge("Information trafic indisponible"));
+    return;
+  }
+
+  const badge = document.createElement("span");
+  badge.className = "line-pill";
+  badge.textContent = item.code || item.label;
+  badge.style.setProperty("--line-color", item.color);
+  badge.style.setProperty("--line-text", item.textColor);
+
+  const text = document.createElement("span");
+  text.className = `line-alert-text ${item.status}`;
+  text.textContent = item.message;
+
+  container.appendChild(badge);
+  container.appendChild(text);
+}
+
+function updateStationStatus(elementId, stationName, trafficItem) {
+  const el = document.getElementById(elementId);
+  if (!el) return;
+
+  let statusClass = "ok";
+  let text = `Station ${stationName} · trafic normal`;
+
+  if (!trafficItem) {
+    statusClass = "unknown";
+    text = `Station ${stationName} · information indisponible`;
+  } else {
+    statusClass = trafficItem.status || "ok";
+    const stationMessage = trafficItem.messages?.find(msg =>
+      msg?.toLowerCase().includes(stationName.toLowerCase())
+    );
+
+    if (stationMessage) {
+      text = stationMessage;
+    } else if (trafficItem.status === "alert") {
+      text = trafficItem.message;
+    } else if (trafficItem.status === "unknown") {
+      text = `Station ${stationName} · information indisponible`;
+    }
+  }
+
+  el.textContent = text;
+  el.className = `block-sub station-status ${statusClass}`;
+}
+
+function formatCourseDate(date) {
+  return date.toLocaleDateString("fr-FR", { weekday: "long", day: "numeric", month: "long" });
+}
+
+function formatCountdown(timestamp) {
+  if (!timestamp) return "--";
+  const diff = timestamp - Date.now();
+  if (diff <= 60000) return "Imminent";
+
+  const totalSeconds = Math.max(0, Math.floor(diff / 1000));
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+
+  if (days > 0) {
+    return `${days} j ${hours.toString().padStart(2, "0")} h`;
+  }
+  if (hours > 0) {
+    return `${hours} h ${minutes.toString().padStart(2, "0")} min`;
+  }
+  return `${Math.max(minutes, 1)} min`;
+}
+
+function updateCourseHeader() {
+  const dateEl = document.getElementById("courses-date");
+  const countdownEl = document.getElementById("courses-countdown");
+  if (!dateEl || !countdownEl) return;
+
+  if (!coursesState.length) {
+    dateEl.textContent = "Aucune course planifiée";
+    countdownEl.textContent = "--";
+    return;
+  }
+
+  const first = coursesState[0];
+  const start = new Date(first.ts);
+  dateEl.textContent = `Courses du ${formatCourseDate(start)}`;
+  countdownEl.textContent = formatCountdown(first.ts);
+}
+
+function updateCourseCountdown() {
+  if (!coursesState.length) return;
+  updateCourseHeader();
+  document.querySelectorAll(".course-countdown").forEach(el => {
+    const ts = Number(el.dataset.countdown);
+    if (Number.isNaN(ts)) return;
+    el.textContent = formatCountdown(ts);
+  });
+}
+
+function renderCourses(courses) {
+  const container = document.getElementById("courses-list");
+  if (!container) return;
+  container.innerHTML = "";
+
+  coursesState = Array.isArray(courses) ? [...courses] : [];
+  updateCourseHeader();
+
+  if (!coursesState.length) {
+    container.appendChild(makeInfoBadge("Pas de prochaine course identifiée."));
+    return;
+  }
+
+  coursesState.forEach(course => {
+    const row = document.createElement("div");
+    row.className = "course-row";
+
+    const time = document.createElement("div");
+    time.className = "course-time";
+    const start = new Date(course.ts);
+    const dateLabel = start.toLocaleDateString("fr-FR", { weekday: "short", day: "2-digit", month: "2-digit" });
+    const hourLabel = start.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
+    time.textContent = `${dateLabel} · ${hourLabel}`;
+
+    const info = document.createElement("div");
+    info.className = "course-info";
+
+    const name = document.createElement("div");
+    name.className = "course-name";
+    name.textContent = course.nom;
+
+    const details = document.createElement("div");
+    details.className = "course-details";
+    const detailParts = [];
+    if (typeof course.distance === "number") detailParts.push(`${course.distance} m`);
+    if (course.discipline) detailParts.push(course.discipline);
+    details.textContent = detailParts.join(" • ");
+
+    info.appendChild(name);
+    info.appendChild(details);
+
+    const countdown = document.createElement("div");
+    countdown.className = "course-countdown";
+    countdown.dataset.countdown = course.ts;
+    countdown.textContent = formatCountdown(course.ts);
+
+    const prize = document.createElement("div");
+    prize.className = "course-prize";
+    const prizeValue = typeof course.dotation === "number" ? (course.dotation / 1000).toFixed(0) : "—";
+    prize.textContent = `${prizeValue} k€`;
+
+    row.appendChild(time);
+    row.appendChild(info);
+    row.appendChild(countdown);
+    row.appendChild(prize);
+    container.appendChild(row);
+  });
+}
+
+function renderWeather(weather) {
+  const tempEl = document.getElementById("weather-temp");
+  const descEl = document.getElementById("weather-desc");
+  const extraEl = document.getElementById("weather-extra");
+  const iconEl = document.getElementById("weather-icon");
+
+  if (!weather?.current_weather) {
+    if (descEl) descEl.textContent = "Météo indisponible";
+    if (tempEl) tempEl.textContent = "--°";
+    if (extraEl) extraEl.textContent = "";
+    if (iconEl) {
+      iconEl.className = "weather-icon weather-unknown";
+      iconEl.innerHTML = '<div class="weather-shape"></div>';
+    }
+    return;
+  }
+
+  const { temperature, windspeed, weathercode } = weather.current_weather;
+  if (tempEl) tempEl.textContent = `${Math.round(temperature)}°`;
+  if (descEl) descEl.textContent = WEATHER_CODES[weathercode] || "Conditions actuelles";
+  if (extraEl) extraEl.textContent = `Vent ${Math.round(windspeed)} km/h`;
+  if (iconEl) {
+    const weatherClass = getWeatherClass(weathercode);
+    iconEl.className = `weather-icon ${weatherClass}`;
+    iconEl.innerHTML = '<div class="weather-shape"></div>';
+  }
+}
+
+function updateNewsCounter() {
+  const counter = document.getElementById("news-counter");
+  if (!counter) return;
+  if (!newsItems.length) {
+    counter.textContent = "0/0";
+  } else {
+    counter.textContent = `${currentNews + 1}/${newsItems.length}`;
+  }
+}
+
+function renderNews(items) {
+  const container = document.getElementById("news-content");
+  if (!container) return;
+  container.innerHTML = "";
+
+  newsItems = items;
+  currentNews = 0;
+
+  if (!items?.length) {
+    container.appendChild(makeInfoBadge("Actualités indisponibles pour le moment."));
+    updateNewsCounter();
+    return;
+  }
+
+  items.forEach((item, index) => {
+    const article = document.createElement("article");
+    article.className = "news-item" + (index === 0 ? " active" : "");
+
+    const title = document.createElement("div");
+    title.className = "news-title";
+    title.textContent = item.title;
+
+    const text = document.createElement("div");
+    text.className = "news-text";
+    text.textContent = item.description;
+
+    const meta = document.createElement("div");
+    meta.className = "news-meta";
+    meta.textContent = item.source || "France Info";
+
+    article.appendChild(title);
+    article.appendChild(text);
+    article.appendChild(meta);
+    container.appendChild(article);
+  });
+
+  updateNewsCounter();
 }
 
 function nextNews() {
   if (!newsItems.length) return;
-  document.querySelector(".news-item.active")?.classList.remove("active");
+  const nodes = document.querySelectorAll(".news-item");
+  if (!nodes.length) return;
+  nodes[currentNews]?.classList.remove("active");
   currentNews = (currentNews + 1) % newsItems.length;
-  document.querySelectorAll(".news-item")[currentNews].classList.add("active");
-  $("#news-counter").textContent = (currentNews + 1) + "/" + newsItems.length;
+  nodes[currentNews]?.classList.add("active");
+  updateNewsCounter();
 }
 
-// --- Traffic ---
-async function getTraffic(lineId, containerId) {
-  const el = document.getElementById(containerId);
-  if (!el) return;
-  el.innerHTML = `<div class="loader">Chargement trafic...</div>`;
-  try {
-    const url = PROXY + encodeURIComponent(
-      `https://prim.iledefrance-mobilites.fr/marketplace/v2/navitia/line_reports/lines/${lineId}`
-    );
+async function fetchTraffic(lineNavitiaId) {
+  const url =
+    PROXY +
+    encodeURIComponent(`https://prim.iledefrance-mobilites.fr/marketplace/v2/navitia/line_reports/lines/${lineNavitiaId}`);
+  const data = await fetchJSON(url, 15000);
+  if (!data) return null;
+
+  const messages = [];
+  (data.line_reports || []).forEach(report => {
+    (report.messages || []).forEach(m => {
+      if (m.text) messages.push(m.text);
+    });
+  });
+  return messages;
+}
+
+async function getVincennes() {
+  const upcoming = [];
+  for (let offset = 0; offset < 3; offset += 1) {
+    const date = new Date();
+    date.setDate(date.getDate() + offset);
+    const pmu = `${String(date.getDate()).padStart(2, "0")}${String(date.getMonth() + 1).padStart(2, "0")}${date.getFullYear()}`;
+    const url = PROXY + encodeURIComponent(`https://offline.turfinfo.api.pmu.fr/rest/client/7/programme/${pmu}`);
     const data = await fetchJSON(url, 15000);
-    el.innerHTML = "";
-    if (data?.line_reports?.length > 0) {
-      data.line_reports.forEach(report => {
-        const msg = report.messages?.[0]?.text || "Perturbation en cours";
-        const div = document.createElement("div");
-        div.className = "traffic-alert";
-        div.innerHTML = `⚠️ ${msg}`;
-        el.appendChild(div);
+    if (!data?.programme?.reunions) continue;
+
+    data.programme.reunions.forEach(reunion => {
+      if (reunion.hippodrome?.code !== "VIN") return;
+      reunion.courses?.forEach(course => {
+        const start = new Date(course.heureDepart);
+        if (Number.isNaN(start.getTime()) || start < new Date()) return;
+        upcoming.push({
+          heure: start.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" }),
+          nom: course.libelle,
+          distance: course.distance,
+          discipline: course.discipline,
+          dotation: course.montantPrix,
+          ts: start.getTime()
+        });
       });
-    } else {
-      const ok = document.createElement("div");
-      ok.className = "traffic-ok";
-      ok.innerHTML = "✅ Trafic normal";
-      el.appendChild(ok);
-    }
-  } catch (e) {
-    console.error("Erreur trafic", e);
-    el.innerHTML = `<div class="traffic-error">❌ Trafic indisponible</div>`;
+    });
+  }
+
+  return upcoming.sort((a, b) => a.ts - b.ts).slice(0, 6);
+}
+
+function renderVelibCard(container, station) {
+  if (!container) return;
+  container.innerHTML = "";
+
+  if (!station) {
+    container.appendChild(makeInfoBadge("Données Vélib' indisponibles."));
+    return;
+  }
+
+  const title = document.createElement("strong");
+  title.textContent = `📍 ${station.name}`;
+
+  const mechanical = document.createElement("span");
+  mechanical.textContent = `🚲 ${station.mechanical ?? "--"} méca`;
+
+  const electric = document.createElement("span");
+  electric.textContent = `🔌 ${station.ebike ?? "--"} élec`;
+
+  const docks = document.createElement("span");
+  docks.textContent = `🅿️ ${station.numdocksavailable ?? "--"} bornes`;
+
+  container.appendChild(title);
+  container.appendChild(mechanical);
+  container.appendChild(electric);
+  container.appendChild(docks);
+}
+
+async function updateVelibCard(stationId, containerId) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+  container.textContent = "Chargement...";
+
+  try {
+    const url =
+      `https://opendata.paris.fr/api/explore/v2.1/catalog/datasets/velib-disponibilite-en-temps-reel/exports/json?lang=fr&qv1=(${stationId})&timezone=Europe%2FParis`;
+    const response = await fetch(url);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const data = await response.json();
+    const station = Array.isArray(data) ? data[0] : null;
+    renderVelibCard(container, station);
+  } catch (error) {
+    console.error("Vélib'", stationId, error.message);
+    renderVelibCard(container, null);
   }
 }
 
-// --- Modules principaux ---
-async function news() {
-  const xml = await fetchText(PROXY + encodeURIComponent(RSS_URL));
-  let actus = [];
-  if (xml) {
-    const doc = new DOMParser().parseFromString(xml, "application/xml");
-    const items = Array.from(doc.querySelectorAll("item")).slice(0, 10);
-    actus = items.map(i => ({
-      title: i.querySelector("title")?.textContent || "",
-      description: i.querySelector("description")?.textContent || ""
-    }));
-  }
-  renderNews(actus);
-}
-
-async function meteo() {
-  const weather = await fetchJSON(WEATHER_URL);
-  if (weather?.current_weather) {
-    $("#meteo-temp").textContent = Math.round(weather.current_weather.temperature);
-    $("#meteo-desc").textContent = "Conditions actuelles";
-    $("#meteo-extra").textContent = "Vent " + weather.current_weather.windspeed + " km/h";
-  }
-}
-
-async function velib() {
-  const velibData = await fetchJSON(PROXY + encodeURIComponent(VELIB_URL), 20000);
-  const velibStations = parseVelibDetailed(velibData);
-  if (velibStations) renderVelib($("#velib-list"), velibStations);
-}
-
-async function transport() {
-  const [rer, jv, hp, br] = await Promise.all([
-    fetchJSON(PROXY + encodeURIComponent("https://prim.iledefrance-mobilites.fr/marketplace/stop-monitoring?MonitoringRef=" + STOP_IDS.RER_A)),
-    fetchJSON(PROXY + encodeURIComponent("https://prim.iledefrance-mobilites.fr/marketplace/stop-monitoring?MonitoringRef=" + STOP_IDS.JOINVILLE_AREA)),
-    fetchJSON(PROXY + encodeURIComponent("https://prim.iledefrance-mobilites.fr/marketplace/stop-monitoring?MonitoringRef=" + STOP_IDS.HIPPODROME)),
-    fetchJSON(PROXY + encodeURIComponent("https://prim.iledefrance-mobilites.fr/marketplace/stop-monitoring?MonitoringRef=" + STOP_IDS.BREUIL))
-  ]);
-
-  const rerData = regroupRER(rer);
-  if (rerData) {
-    renderRER($("#rer-paris"), rerData.directionParis);
-    renderRER($("#rer-boissy"), rerData.directionBoissy);
-  }
-  const jvData = parseStop(jv);
-  if (jvData) renderBus($("#bus-joinville-list"), jvData, "joinville");
-  const hpData = parseStop(hp);
-  if (hpData) renderBus($("#bus-hippodrome-list"), hpData, "hippodrome");
-  const brData = parseStop(br);
-  if (brData) renderBus($("#bus-breuil-list"), brData, "breuil");
-}
-
-async function courses() {
-  const vincennesCourses = await getVincennes();
-  if (vincennesCourses) renderCourses($("#courses-list"), vincennesCourses);
-}
-
-// --- Boucles ---
-function startAllLoops() {
-  setInterval(transport, 60 * 1000);
-  setInterval(courses, 5 * 60 * 1000);
-  setInterval(velib, 10 * 60 * 1000);
-  setInterval(news, 15 * 60 * 1000);
-  setInterval(meteo, 30 * 60 * 1000);
-
-  setInterval(() => getTraffic(LINES.RER_A, "traffic-rer"), 5 * 60 * 1000);
-  setInterval(() => getTraffic(LINES.BUS_77, "traffic-77"), 5 * 60 * 1000);
-  setInterval(() => getTraffic(LINES.BUS_201, "traffic-201"), 5 * 60 * 1000);
-
-  setInterval(nextNews, 20000);
-  setInterval(setClock, 1000);
-  setClock();
-}
-
-// --- Initialisation ---
-async function initialRefresh() {
+async function updateVelibCards() {
   await Promise.all([
-    transport(),
-    courses(),
-     startVelibLoop(),
-
-    news(),
-    meteo(),
-    getTraffic(LINES.RER_A, "traffic-rer"),
-    getTraffic(LINES.BUS_77, "traffic-77"),
-    getTraffic(LINES.BUS_201, "traffic-201")
+    updateVelibCard(VELIB_STATIONS.VINCENNES, "velib-vincennes"),
+    updateVelibCard(VELIB_STATIONS.BREUIL, "velib-breuil")
   ]);
-  setLastUpdate();
+
+  const el = document.getElementById("velib-update");
+  if (el) {
+    el.textContent = `Mise à jour : ${new Date().toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" })}`;
+  }
 }
 
-async function initDashboard() {
-  await initialRefresh();
-  startAllLoops();
+function normaliseSytadinEntries(data) {
+  if (!data) return [];
+  let source = [];
+  if (Array.isArray(data)) {
+    source = data;
+  } else if (Array.isArray(data?.axes)) {
+    source = data.axes;
+  } else if (Array.isArray(data?.records)) {
+    source = data.records.map(record => record.fields || record);
+  } else if (Array.isArray(data?.features)) {
+    source = data.features.map(feature => feature.properties || feature);
+  }
+
+  return source
+    .map(item => {
+      const name = cleanText(
+        item.libelle || item.axis || item.name || item.nom || item.route || item.axe || ""
+      );
+      const direction = cleanText(item.sens || item.direction || item.itineraire || item.dest || "");
+      const status = item.indice_trafic ?? item.indice ?? item.indice_congestion ?? item.status ?? item.etat;
+      const travel =
+        item.temps ?? item.temps_parcours ?? item.travel_time ?? item.duree ?? item.duree_parcours ?? item.tps;
+      const length = item.longueur ?? item.longueur_bouchon ?? item.bouchon ?? item.length ?? item.km;
+      const note = cleanText(item.message || item.commentaire || item.detail || item.description || "");
+      const updated = item.horodatage || item.date_maj || item.last_update || item.datetime || item.date;
+
+      return {
+        name,
+        direction,
+        status,
+        travel,
+        length,
+        note,
+        updated,
+        raw: item
+      };
+    })
+    .filter(entry => entry.name);
 }
 
-initDashboard();
+function interpretSytadinStatus(entry) {
+  if (typeof entry.status === "number" && SYTADIN_STATUS_LOOKUP[entry.status]) {
+    return SYTADIN_STATUS_LOOKUP[entry.status];
+  }
+
+  const str = (entry.status || "").toString().toLowerCase();
+  if (!str) return { text: "Indisponible", className: "unknown", severity: 0 };
+  if (str.includes("fluide")) return { text: "Fluide", className: "fluid", severity: 1 };
+  if (str.includes("dense") || str.includes("ralenti")) return { text: "Dense", className: "dense", severity: 2 };
+  if (str.includes("bouch") || str.includes("congestion") || str.includes("bloqu")) {
+    return { text: "Bouchons", className: "jam", severity: 3 };
+  }
+  return { text: cleanText(entry.status), className: "unknown", severity: 1 };
+}
+
+function formatTravelTime(value) {
+  if (value == null || value === "") return null;
+  if (typeof value === "number") return `${Math.round(value)} min`;
+  const str = value.toString().trim();
+  if (!str) return null;
+  const numeric = Number(str.replace(",", "."));
+  if (!Number.isNaN(numeric)) return `${Math.round(numeric)} min`;
+  return cleanText(str);
+}
+
+function formatDistance(value) {
+  if (value == null || value === "") return null;
+  if (typeof value === "number") {
+    const display = value >= 10 ? Math.round(value) : Math.round(value * 10) / 10;
+    return `${display} km`;
+  }
+  const str = value.toString().trim();
+  if (!str) return null;
+  const numeric = Number(str.replace(",", "."));
+  if (!Number.isNaN(numeric)) {
+    const display = numeric >= 10 ? Math.round(numeric) : Math.round(numeric * 10) / 10;
+    return `${display} km`;
+  }
+  return cleanText(str);
+}
+
+function filterSytadinEntries(entries) {
+  if (!entries.length) return [];
+  const enriched = entries.map(entry => ({
+    ...entry,
+    statusInfo: interpretSytadinStatus(entry),
+    travelLabel: formatTravelTime(entry.travel),
+    lengthLabel: formatDistance(entry.length)
+  }));
+
+  const matched = enriched.filter(entry => {
+    const label = `${entry.name} ${entry.direction}`.toLowerCase();
+    return SYTADIN_KEYWORDS.some(regex => regex.test(label));
+  });
+
+  const base = matched.length ? matched : enriched;
+  return base.sort((a, b) => (b.statusInfo.severity || 0) - (a.statusInfo.severity || 0)).slice(0, 5);
+}
+
+function renderSytadin(data) {
+  const list = document.getElementById("sytadin-list");
+  const update = document.getElementById("sytadin-update");
+  if (!list || !update) return;
+
+  list.innerHTML = "";
+  const entries = filterSytadinEntries(normaliseSytadinEntries(data));
+
+  if (!entries.length) {
+    list.appendChild(makeInfoBadge("Information trafic Sytadin indisponible."));
+    update.textContent = "Mise à jour indisponible";
+    return;
+  }
+
+  const latest = entries
+    .map(entry => {
+      if (!entry.updated) return null;
+      const time = new Date(entry.updated).getTime();
+      return Number.isNaN(time) ? null : time;
+    })
+    .filter(Boolean)
+    .sort((a, b) => b - a)[0];
+
+  update.textContent = latest
+    ? `Mise à jour : ${new Date(latest).toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" })}`
+    : "Mise à jour : --:--";
+
+  entries.forEach(entry => {
+    const card = document.createElement("article");
+    card.className = "road-card";
+
+    const header = document.createElement("div");
+    header.className = "road-header";
+
+    const axis = document.createElement("div");
+    axis.className = "road-axis";
+    axis.textContent = entry.direction ? `${entry.name} · ${entry.direction}` : entry.name;
+
+    const status = document.createElement("span");
+    status.className = `road-status ${entry.statusInfo.className}`;
+    status.textContent = entry.statusInfo.text;
+
+    header.appendChild(axis);
+    header.appendChild(status);
+    card.appendChild(header);
+
+    const meta = document.createElement("div");
+    meta.className = "road-meta";
+
+    if (entry.travelLabel) {
+      const travel = document.createElement("span");
+      travel.textContent = `Trajet : ${entry.travelLabel}`;
+      meta.appendChild(travel);
+    }
+
+    if (entry.lengthLabel) {
+      const length = document.createElement("span");
+      length.textContent = `Bouchon : ${entry.lengthLabel}`;
+      meta.appendChild(length);
+    }
+
+    if (meta.childElementCount) {
+      card.appendChild(meta);
+    }
+
+    if (entry.note) {
+      const note = document.createElement("p");
+      note.className = "road-note";
+      note.textContent = entry.note;
+      card.appendChild(note);
+    }
+
+    list.appendChild(card);
+  });
+}
+
+async function refreshSytadin() {
+  try {
+    const data = await fetchJSON(PROXY + encodeURIComponent(SYTADIN_URL), 15000);
+    renderSytadin(data);
+  } catch (error) {
+    console.error("Sytadin", error);
+    renderSytadin(null);
+  }
+}
+
+async function refreshTransport() {
+  try {
+    const [
+      rerRaw,
+      joinvilleRaw,
+      hippodromeRaw,
+      breuilRaw,
+      trafficRer,
+      traffic77,
+      traffic106,
+      traffic201
+    ] = await Promise.all([
+      fetchJSON(
+        PROXY +
+          encodeURIComponent(
+            `https://prim.iledefrance-mobilites.fr/marketplace/stop-monitoring?MonitoringRef=${STOP_IDS.RER_A}`
+          ),
+        15000
+      ),
+      fetchJSON(
+        PROXY +
+          encodeURIComponent(
+            `https://prim.iledefrance-mobilites.fr/marketplace/stop-monitoring?MonitoringRef=${STOP_IDS.JOINVILLE_AREA}`
+          ),
+        15000
+      ),
+      fetchJSON(
+        PROXY +
+          encodeURIComponent(
+            `https://prim.iledefrance-mobilites.fr/marketplace/stop-monitoring?MonitoringRef=${STOP_IDS.HIPPODROME}`
+          ),
+        15000
+      ),
+      fetchJSON(
+        PROXY +
+          encodeURIComponent(
+            `https://prim.iledefrance-mobilites.fr/marketplace/stop-monitoring?MonitoringRef=${STOP_IDS.BREUIL}`
+          ),
+        15000
+      ),
+      fetchTraffic(LINES.RER_A.navitia),
+      fetchTraffic(LINES.BUS_77.navitia),
+      fetchTraffic(LINES.BUS_106.navitia),
+      fetchTraffic(LINES.BUS_201.navitia)
+    ]);
+
+    const rerVisits = parseStop(rerRaw);
+    const joinvilleVisits = parseStop(joinvilleRaw);
+    const hippodromeVisits = parseStop(hippodromeRaw);
+    const breuilVisits = parseStop(breuilRaw);
+
+    const trafficItems = await Promise.all([
+      buildTrafficItem(LINES.RER_A, trafficRer),
+      buildTrafficItem(LINES.BUS_77, traffic77),
+      buildTrafficItem(LINES.BUS_106, traffic106),
+      buildTrafficItem(LINES.BUS_201, traffic201)
+    ]);
+
+    const trafficMap = {};
+    trafficItems.filter(Boolean).forEach(item => {
+      trafficMap[item.id] = item;
+    });
+
+    renderRerBlock(rerVisits, trafficMap[LINES.RER_A.id]);
+    await renderBusBoard([...joinvilleVisits, ...hippodromeVisits, ...breuilVisits], trafficMap);
+    setLastUpdate();
+  } catch (error) {
+    console.error("refreshTransport", error);
+  }
+}
+
+async function refreshWeather() {
+  const data = await fetchJSON(WEATHER_URL, 10000);
+  renderWeather(data);
+}
+
+async function refreshCourses() {
+  const courses = await getVincennes();
+  renderCourses(courses);
+}
+
+async function refreshNews() {
+  const xml = await fetchText(PROXY + encodeURIComponent(RSS_URL), 15000);
+  let items = [];
+  if (xml) {
+    try {
+      const doc = new DOMParser().parseFromString(xml, "application/xml");
+      const nodes = Array.from(doc.querySelectorAll("item")).slice(0, 10);
+      items = nodes.map(node => ({
+        title: cleanText(node.querySelector("title")?.textContent || ""),
+        description: cleanText(node.querySelector("description")?.textContent || ""),
+        source: cleanText(node.querySelector("source")?.textContent || "France Info")
+      }));
+    } catch (error) {
+      console.error("RSS parse", error);
+    }
+  }
+  renderNews(items);
+}
+
+function startLoops() {
+  setInterval(refreshTransport, 60 * 1000);
+  setInterval(refreshWeather, 30 * 60 * 1000);
+  setInterval(refreshCourses, 5 * 60 * 1000);
+  setInterval(refreshNews, 15 * 60 * 1000);
+  setInterval(updateVelibCards, 3 * 60 * 1000);
+  setInterval(refreshSytadin, 5 * 60 * 1000);
+  setInterval(nextNews, 20000);
+  setInterval(updateCourseCountdown, 1000);
+  setInterval(setClock, 1000);
+}
+
+async function init() {
+  setClock();
+
+  await Promise.all([
+    refreshTransport(),
+    refreshWeather(),
+    refreshCourses(),
+    refreshNews(),
+    updateVelibCards(),
+    refreshSytadin()
+  ]);
+
+  startLoops();
+}
+
+init();

--- a/index.html
+++ b/index.html
@@ -1,78 +1,120 @@
 <!DOCTYPE html>
 <html lang="fr">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Affichage Dynamique – Hippodrome Paris-Vincennes</title>
-  <link rel="stylesheet" href="styles.css">
-</head>
-<body>
-  <div class="app" role="application" aria-label="Affichage dynamique – Hippodrome Paris-Vincennes">
-    <header>
-      <div class="brand">Dashboard Hippodrome <small>– LIVE via Proxy</small></div>
-      <div class="spacer"></div>
-      <div id="lastUpdate" class="muted" aria-live="polite"></div>
-      <div id="clock" class="clock" aria-label="Heure"></div>
-    </header>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Affichage dynamique – Hippodrome Paris-Vincennes</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="app" role="application" aria-label="Affichage dynamique – Hippodrome Paris-Vincennes">
+      <header class="app-header">
+        <div class="branding">
+          <p class="brand-title">Hippodrome Paris-Vincennes</p>
+          <p class="brand-sub">Tableau d'information voyageurs</p>
+        </div>
+        <div class="weather-widget" aria-live="polite">
+          <div id="weather-icon" class="weather-icon weather-unknown" aria-hidden="true">
+            <div class="weather-shape"></div>
+          </div>
+          <div class="weather-data">
+            <span id="weather-temp" class="weather-temp">--°</span>
+            <div class="weather-details">
+              <span id="weather-desc" class="weather-desc">Chargement...</span>
+              <span id="weather-extra" class="weather-extra"></span>
+            </div>
+          </div>
+        </div>
+        <div class="header-right">
+          <div id="lastUpdate" class="last-update" aria-live="polite">Maj --:--</div>
+          <div id="clock" class="clock" aria-live="off">--:--</div>
+        </div>
+      </header>
 
-    <div class="dashboard-container">
+      <main class="dashboard-grid">
+        <section class="block block-rer" aria-labelledby="rer-title">
+          <div class="block-header block-header--stacked">
+            <div class="block-heading">
+              <h2 id="rer-title">RER A</h2>
+              <p id="rer-station-info" class="block-sub station-status">Station Joinville-le-Pont · chargement...</p>
+            </div>
+            <div id="traffic-rer-line" class="line-alert" aria-live="polite"></div>
+          </div>
+          <div class="block-body rer-body">
+            <div class="rer-column">
+              <h3>Vers Paris</h3>
+              <div id="rer-paris" class="rer-list" role="list"></div>
+            </div>
+            <div class="rer-column">
+              <h3>Vers Boissy / Marne-la-Vallée</h3>
+              <div id="rer-boissy" class="rer-list" role="list"></div>
+            </div>
+            <div class="rer-column">
+              <h3>Autres destinations</h3>
+              <div id="rer-other" class="rer-list" role="list"></div>
+            </div>
+          </div>
+        </section>
 
-      <!-- RER A -->
-      <div class="block" id="rer-section">
-        <h3>RER A - Joinville-le-Pont</h3>
-        <div id="rer-paris"></div>
-        <div id="rer-boissy"></div>
-        <div id="traffic-rer" class="traffic-container"></div>
-      </div>
+        <section class="block block-bus" aria-labelledby="bus-title">
+          <div class="block-header block-header--stacked">
+            <div class="block-heading">
+              <h2 id="bus-title">Bus</h2>
+              <p id="bus-summary" class="block-sub bus-summary">Chargement...</p>
+            </div>
+            <div id="bus-traffic" class="bus-traffic" aria-live="polite"></div>
+          </div>
+          <div class="block-body bus-body">
+            <div id="bus-stations" class="bus-stations" role="list"></div>
+          </div>
+        </section>
 
-      <!-- Météo -->
-      <div class="block" id="meteo-panel">
-        <h3>Météo Locale</h3>
-        <div id="meteo-temp">--</div>
-        <div id="meteo-desc">Chargement...</div>
-        <div id="meteo-extra"></div>
-      </div>
+        <section class="block block-courses" aria-labelledby="courses-title">
+          <div class="block-header block-header--stacked">
+            <div class="block-heading">
+              <h2 id="courses-title">Courses à Vincennes</h2>
+              <p id="courses-date" class="block-sub">Chargement...</p>
+            </div>
+            <div id="courses-countdown" class="countdown-chip" aria-live="polite">--</div>
+          </div>
+          <div id="courses-list" class="block-body courses-list" role="list"></div>
+        </section>
 
-      <!-- Bus Joinville -->
-      <div class="block" id="bus-joinville-list">
-        <h3>Bus Joinville-le-Pont</h3>
-        <div id="traffic-77" class="traffic-container"></div>
-        <div id="traffic-201" class="traffic-container"></div>
-      </div>
+        <section class="block block-road" aria-labelledby="road-title">
+          <div class="block-header block-header--stacked">
+            <div class="block-heading">
+              <h2 id="road-title">Info trafic Sytadin</h2>
+              <p id="sytadin-update" class="block-sub">Chargement...</p>
+            </div>
+          </div>
+          <div id="sytadin-content" class="block-body road-body">
+            <div id="sytadin-list" class="road-list" role="list"></div>
+          </div>
+        </section>
 
-      <!-- Bus Hippodrome -->
-      <div class="block" id="bus-hippodrome-list">
-        <h3>Bus Hippodrome</h3>
-      </div>
+        <section class="block block-news" aria-labelledby="news-title">
+          <div class="block-header">
+            <h2 id="news-title">Actualités</h2>
+            <span id="news-counter" class="news-counter" aria-live="polite">0/0</span>
+          </div>
+          <div class="block-body news-body">
+            <div id="news-content" class="news-content" aria-live="polite"></div>
+          </div>
+        </section>
 
-      <!-- Bus École du Breuil -->
-      <div class="block" id="bus-breuil-list">
-        <h3>Bus École du Breuil</h3>
-      </div>
-
-      <!-- Vélib -->
-      <div class="block" id="velib-section">
-<div id="velib-vincennes"></div>
-<div id="velib-breuil"></div>
-<div id="velib-update" class="muted"></div>
-
-      </div>
-
-      <!-- Courses -->
-      <div class="block" id="courses-section">
-        <h3>Prochaines Courses Vincennes</h3>
-        <div id="courses-list"></div>
-      </div>
-
-      <!-- Actualités -->
-      <div class="block" id="actualites-section">
-        <h3>Actualités</h3>
-        <div id="news-content"></div>
-        <span id="news-counter">0/0</span>
-      </div>
-
+        <section class="block block-velib" aria-labelledby="velib-title">
+          <div class="block-header">
+            <h2 id="velib-title">Vélib'</h2>
+          </div>
+          <div class="block-body velib-body">
+            <div id="velib-vincennes" class="velib-card"></div>
+            <div id="velib-breuil" class="velib-card"></div>
+            <div id="velib-update" class="velib-update"></div>
+          </div>
+        </section>
+      </main>
     </div>
-  </div>
-  <script src="app.js"></script>
-</body>
+
+    <script src="app.js"></script>
+  </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,319 +1,1314 @@
-/* styles.css */
-
-/* Variables */
 :root {
-  --bg: #0f1115;
-  --text: #040f2b;
-  --muted: #a9b1c3;
-  --accent: #ffd400;
-  --border: #1f2633;
-  --rerA: #e51c23;
-  --idfm-blue: #0087CE;
-  --vincennes: #8B4513;
-  --joinville: #2E8B57;
-  --hippodrome: #4682B4;
-  --breuil: #DAA520;
-  --velib-meca-bg: #f0fdf4;
-  --velib-eq-bg: #eff6ff;
-  --velib-docks-bg: #f8fafc;
+  --bg: radial-gradient(circle at 15% 15%, #0f2042 0%, #06132b 32%, #030b1c 100%);
+  --panel: #0a1f45;
+  --panel-alt: #112b5e;
+  --border: rgba(90, 133, 206, 0.22);
+  --text: #f4f7ff;
+  --muted: #a6b8d9;
+  --accent: #ffd43b;
+  --chip-bg: rgba(76, 110, 178, 0.2);
+  --chip-text: #f4f7ff;
+  --success: #3dd6b5;
+  --warning: #f6c65b;
+  --danger: #ff8f8f;
+  --info: #4dabff;
 }
 
-/* Global */
-* { box-sizing: border-box; }
-html, body { height: 100%; margin: 0; background: var(--bg); color: var(--text); font-family: system-ui; }
-.app { display: grid; grid-template-rows: 64px 1fr; height: 100vh; }
-
-/* Header */
-header { display: flex; align-items: center; padding: 0 16px; border-bottom: 1px solid var(--border); background: linear-gradient(180deg, #0f1626, #0d1322); }
-.brand { font-weight: 800; letter-spacing: .2px; }
-.brand small { color: var(--muted); font-weight: 600; }
-.spacer { flex: 1; }
-.clock { background: #000; padding: 6px 10px; border-radius: 6px; color: var(--accent); font-weight: 800; font-variant-numeric: tabular-nums; border: 1px solid #222; }
-
-/* Main Grid */
-.main-grid { display: grid; gap: 14px; padding: 14px; height: 100%; 
-  grid-template-columns: 1fr 1fr 1fr; grid-template-rows: 250px 180px 180px 120px;
+* {
+  box-sizing: border-box;
 }
 
-/* Block */
-.block {
-  background-color: #1a1d24;   /* fond sombre */
-  color: var(--text);          /* texte clair */
-  border: 1px solid #2c3344;
-  border-radius: 10px;
-  padding: 0;                  /* on laisse le header/body gérer l'espacement */
-  box-shadow: 0 2px 6px rgba(0,0,0,0.5);
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+  background-color: #030b1c;
+  background-image: var(--bg);
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-attachment: fixed;
+  color: var(--text);
   display: flex;
-  flex-direction: column;
   overflow: hidden;
 }
 
-/* Header de bloc */
-.bloc-hd {
+.app {
+  flex: 1;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  min-height: 0;
+  height: 100vh;
+}
+
+.app-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 28px;
+  padding: 22px 32px;
+  background: linear-gradient(135deg, rgba(18, 45, 98, 0.96), rgba(6, 18, 42, 0.92));
+  border-bottom: 1px solid rgba(94, 138, 210, 0.28);
+  box-shadow: 0 18px 46px rgba(2, 10, 28, 0.6);
+}
+
+.branding {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.brand-title {
+  margin: 0;
+  font-size: clamp(1.2rem, 1rem + 0.6vw, 1.6rem);
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.brand-sub {
+  margin: 0;
+  font-size: clamp(0.8rem, 0.75rem + 0.2vw, 1rem);
+  color: var(--muted);
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.last-update {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.clock {
+  padding: 8px 16px;
+  border-radius: 12px;
+  background: rgba(13, 27, 51, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  font-size: clamp(1rem, 0.9rem + 0.3vw, 1.3rem);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  font-variant-numeric: tabular-nums;
+  color: var(--accent);
+}
+
+.weather-widget {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 18px;
+  border-radius: 18px;
+  background: linear-gradient(150deg, rgba(15, 38, 84, 0.86), rgba(8, 21, 52, 0.8));
+  border: 1px solid rgba(96, 138, 212, 0.22);
+  box-shadow: 0 14px 32px rgba(2, 12, 32, 0.5);
+  min-width: 240px;
+}
+
+.weather-icon {
+  position: relative;
+  width: 64px;
+  height: 64px;
+  flex: 0 0 auto;
+}
+
+.weather-icon .weather-shape {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, #ffe066 0%, #ff922b 70%);
+  box-shadow: 0 0 25px rgba(255, 194, 61, 0.45);
+  animation: weather-pulse 6s ease-in-out infinite;
+}
+
+.weather-icon::before,
+.weather-icon::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.weather-icon.weather-sun::before {
+  inset: 6px;
+  border-radius: 50%;
+  border: 4px solid rgba(255, 220, 90, 0.6);
+  opacity: 1;
+  animation: weather-spin 14s linear infinite;
+}
+
+.weather-icon.weather-sun::after {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  background: #ffd43b;
+  top: -6px;
+  left: 50%;
+  transform: translateX(-50%);
+  box-shadow: 0 58px 0 #ffd43b, 38px 38px 0 #ffd43b, -38px 38px 0 #ffd43b, 58px 0 0 #ffd43b,
+    -58px 0 0 #ffd43b, 38px -38px 0 #ffd43b, -38px -38px 0 #ffd43b;
+  opacity: 1;
+  animation: weather-spin 14s linear infinite;
+}
+
+.weather-icon.weather-cloud .weather-shape {
+  top: 28%;
+  left: 20%;
+  width: 60%;
+  height: 48%;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #dbe7ff, #9ab6ec);
+  box-shadow: -20px 10px 0 -6px rgba(219, 231, 255, 0.9), 20px 10px 0 -6px rgba(219, 231, 255, 0.9),
+    0 18px 24px rgba(0, 0, 0, 0.35);
+}
+
+.weather-icon.weather-cloud::before {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: rgba(198, 216, 247, 0.95);
+  top: 36%;
+  left: 0;
+  box-shadow: 26px 0 0 rgba(198, 216, 247, 0.95), 13px -12px 0 rgba(224, 233, 250, 0.95);
+  opacity: 1;
+  animation: weather-drift 12s ease-in-out infinite;
+}
+
+.weather-icon.weather-rain .weather-shape,
+.weather-icon.weather-storm .weather-shape {
+  top: 30%;
+  left: 18%;
+  width: 64%;
+  height: 46%;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #c4d7f8, #8fa9dd);
+  box-shadow: -18px 10px 0 -6px rgba(196, 215, 248, 0.95), 18px 10px 0 -6px rgba(196, 215, 248, 0.95),
+    0 20px 24px rgba(0, 0, 0, 0.4);
+}
+
+.weather-icon.weather-rain::before {
+  width: 8px;
+  height: 18px;
+  border-radius: 4px;
+  background: #74c0fc;
+  top: 68%;
+  left: 38%;
+  box-shadow: 16px 6px 0 rgba(116, 192, 252, 0.9), -16px 6px 0 rgba(116, 192, 252, 0.7);
+  opacity: 1;
+  animation: weather-rain 1.8s linear infinite;
+}
+
+.weather-icon.weather-storm::before {
+  width: 10px;
+  height: 28px;
+  background: linear-gradient(180deg, #ffe066 0%, #ffa94d 100%);
+  top: 68%;
+  left: 48%;
+  transform: skewX(-18deg);
+  box-shadow: -14px 6px 0 rgba(255, 224, 102, 0.75);
+  opacity: 1;
+  animation: weather-flash 2.6s ease-in-out infinite;
+}
+
+.weather-icon.weather-fog .weather-shape {
+  inset: 12px 4px;
+  border-radius: 18px;
+  background: linear-gradient(90deg, rgba(200, 210, 230, 0.65), rgba(165, 180, 205, 0.35));
+  box-shadow: 0 0 30px rgba(150, 170, 200, 0.4);
+}
+
+.weather-icon.weather-fog::before {
+  content: "";
+  position: absolute;
+  height: 4px;
+  width: 80%;
+  border-radius: 4px;
+  background: rgba(200, 210, 230, 0.55);
+  left: 10%;
+  top: 28%;
+  box-shadow: 0 14px 0 rgba(200, 210, 230, 0.4), 0 28px 0 rgba(200, 210, 230, 0.3);
+  opacity: 1;
+  animation: weather-drift 8s ease-in-out infinite;
+}
+
+.weather-icon.weather-unknown .weather-shape {
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.55) 0%, rgba(132, 160, 210, 0.35) 70%);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+}
+
+.weather-data {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.weather-temp {
+  font-size: clamp(2rem, 1.6rem + 1vw, 3rem);
+  font-weight: 700;
+  line-height: 1;
+}
+
+.weather-details {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.weather-desc {
+  font-weight: 600;
+  font-size: clamp(0.95rem, 0.9rem + 0.2vw, 1.1rem);
+}
+
+.weather-extra {
+  font-size: clamp(0.75rem, 0.7rem + 0.18vw, 0.9rem);
+  color: var(--muted);
+}
+
+.dashboard-grid {
+  display: grid;
+  gap: 26px;
+  padding: 28px 32px 32px;
+  grid-template-columns: minmax(0, 1.25fr) minmax(0, 0.9fr);
+  grid-template-rows: auto minmax(0, 1fr) auto auto;
+  grid-template-areas:
+    "rer news"
+    "bus courses"
+    "bus road"
+    "bus velib";
+  align-content: stretch;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.block {
+  position: relative;
+  background: linear-gradient(165deg, rgba(12, 31, 68, 0.94), rgba(7, 21, 47, 0.92));
+  border: 1px solid rgba(94, 138, 210, 0.26);
+  border-radius: 22px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-height: 0;
+  box-shadow: 0 20px 48px rgba(3, 12, 32, 0.62);
+  backdrop-filter: blur(10px);
+}
+
+.block::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(130deg, rgba(84, 138, 255, 0.12), rgba(255, 255, 255, 0));
+  pointer-events: none;
+}
+
+.block-header {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px 24px 18px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0));
+  border-bottom: 1px solid rgba(116, 156, 228, 0.18);
+  z-index: 1;
+}
+
+.block-header--stacked {
+  align-items: flex-start;
+}
+
+.block-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.block-header h2 {
+  margin: 0;
+  font-size: clamp(1.05rem, 0.95rem + 0.45vw, 1.4rem);
+  font-weight: 700;
+}
+
+.block-sub {
+  margin: 0;
+  font-size: clamp(0.78rem, 0.72rem + 0.2vw, 0.95rem);
+  color: var(--muted);
+}
+
+.block-body {
+  position: relative;
+  flex: 1;
+  padding: 20px 24px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 0;
+  z-index: 1;
+}
+
+.block-rer,
+.block-bus,
+.block-courses,
+.block-road,
+.block-news,
+.block-velib {
+  min-height: 0;
+}
+
+.block-rer {
+  grid-area: rer;
+}
+
+.block-bus {
+  grid-area: bus;
+}
+
+.block-courses {
+  grid-area: courses;
+}
+
+.block-road {
+  grid-area: road;
+}
+
+.block-news {
+  grid-area: news;
+}
+
+.block-velib {
+  grid-area: velib;
+}
+
+.line-alert {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 12px 14px;
-  border-bottom: 1px solid #2c3344;
-  font-weight: 900;
-  font-size: 16px;
-  background: #11141c;         /* léger contraste */
-  color: var(--accent);        /* accent jaune */
+  font-size: clamp(0.75rem, 0.7rem + 0.18vw, 0.9rem);
+  color: var(--muted);
+  min-height: 24px;
 }
 
-/* Petit tag (optionnel dans header) */
-.bloc-hd .tag {
-  font-size: 11px;
-  padding: 3px 6px;
-  border-radius: 999px;
-  background: rgba(255,255,255,0.08);
-  border: 1px solid #2c3344;
-  color: var(--text);
+.line-alert-text {
+  font-weight: 600;
 }
 
-/* Corps de bloc */
-.bloc-bd {
-  padding: 12px;
+.line-alert-text.ok {
+  color: var(--success);
+}
+
+.line-alert-text.alert {
+  color: var(--warning);
+}
+
+.line-alert-text.unknown {
+  color: var(--danger);
+}
+
+.station-status.ok {
+  color: var(--success);
+}
+
+.station-status.alert {
+  color: var(--warning);
+}
+
+.station-status.unknown {
+  color: var(--danger);
+}
+
+.bus-summary {
+  transition: color 0.3s ease;
+  color: var(--muted);
+}
+
+.bus-summary.ok {
+  color: var(--success);
+}
+
+.bus-summary.alert {
+  color: var(--warning);
+}
+
+.bus-summary.unknown {
+  color: var(--danger);
+}
+
+.rer-body {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+  height: 100%;
+}
+
+.rer-column {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+}
+
+.rer-column h3 {
+  margin: 0;
+  font-size: clamp(0.85rem, 0.8rem + 0.2vw, 1rem);
+  font-weight: 600;
+  color: rgba(196, 210, 240, 0.9);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.rer-list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.rer-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(14, 38, 86, 0.86), rgba(9, 26, 58, 0.74));
+  border: 1px solid rgba(100, 140, 214, 0.18);
+  box-shadow: 0 14px 28px rgba(4, 12, 34, 0.45);
+}
+
+.rer-destination {
   flex: 1;
+  font-weight: 600;
+  font-size: clamp(0.86rem, 0.82rem + 0.2vw, 1.05rem);
+}
+
+.rer-status {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  max-width: 160px;
+}
+
+.rer-times {
+  display: flex;
+  gap: 12px;
+  flex: 0 0 auto;
+}
+
+.time-chip {
+  --time-chip-text: var(--chip-text);
+  --time-chip-sub: rgba(214, 222, 247, 0.85);
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-width: 74px;
+  padding: 10px 14px;
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(59, 130, 246, 0.28), rgba(59, 130, 246, 0.12));
+  color: var(--time-chip-text);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.01em;
+  gap: 2px;
+  text-align: center;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08), 0 10px 24px rgba(8, 20, 44, 0.55);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.time-chip-main {
+  font-size: clamp(1.05rem, 0.95rem + 0.6vw, 1.45rem);
+  font-weight: 700;
+  line-height: 1;
+}
+
+.time-chip-sub {
+  font-size: clamp(0.65rem, 0.62rem + 0.15vw, 0.78rem);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--time-chip-sub);
+  white-space: nowrap;
+}
+
+.time-chip--regular {
+  background: linear-gradient(180deg, rgba(37, 99, 235, 0.3), rgba(37, 99, 235, 0.14));
+}
+
+.time-chip--soon {
+  background: linear-gradient(180deg, rgba(16, 185, 129, 0.35), rgba(16, 185, 129, 0.16));
+  --time-chip-text: #042f2e;
+  --time-chip-sub: rgba(4, 47, 46, 0.7);
+  box-shadow: inset 0 0 0 1px rgba(16, 185, 129, 0.28), 0 12px 26px rgba(4, 47, 46, 0.35);
+}
+
+.time-chip--now {
+  background: linear-gradient(180deg, #ffd43b 0%, #ff922b 95%);
+  --time-chip-text: #221605;
+  --time-chip-sub: rgba(34, 22, 5, 0.76);
+  box-shadow: 0 0 22px rgba(255, 200, 60, 0.55);
+}
+
+.time-chip--long {
+  background: linear-gradient(180deg, rgba(148, 163, 184, 0.25), rgba(148, 163, 184, 0.12));
+  --time-chip-sub: rgba(220, 226, 238, 0.85);
+}
+
+.time-chip--unknown {
+  background: rgba(100, 116, 139, 0.2);
+  --time-chip-text: rgba(226, 232, 240, 0.95);
+  --time-chip-sub: rgba(148, 163, 184, 0.8);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+}
+
+@media (hover: hover) {
+  .time-chip:hover {
+    transform: translateY(-3px);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12), 0 16px 32px rgba(8, 20, 44, 0.6);
+  }
+}
+
+.info-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: 10px;
+  background: rgba(78, 110, 178, 0.24);
+  border: 1px solid rgba(120, 162, 226, 0.22);
+  color: rgba(220, 230, 255, 0.85);
+  font-size: clamp(0.72rem, 0.68rem + 0.18vw, 0.86rem);
+  font-weight: 500;
+}
+
+.line-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 48px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: clamp(0.8rem, 0.75rem + 0.2vw, 1rem);
+  letter-spacing: 0.05em;
+  background: var(--line-color, rgba(255, 255, 255, 0.12));
+  color: var(--line-text, var(--text));
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  box-shadow: 0 10px 22px rgba(4, 16, 40, 0.45);
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: clamp(0.66rem, 0.63rem + 0.12vw, 0.78rem);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+}
+
+.status-chip.status-normal {
+  background: rgba(20, 184, 166, 0.16);
+  color: var(--success);
+}
+
+.status-chip.status-delay {
+  background: rgba(245, 158, 11, 0.18);
+  color: var(--warning);
+}
+
+.status-chip.status-cancelled {
+  background: rgba(248, 113, 113, 0.18);
+  color: var(--danger);
+}
+
+.status-chip.status-first,
+.status-chip.status-last {
+  background: rgba(56, 189, 248, 0.18);
+  color: var(--info);
+}
+
+.status-chip.status-ended {
+  background: rgba(255, 150, 128, 0.2);
+  color: #ff8787;
+}
+
+
+.status-chip.status-unknown {
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--muted);
+}
+
+.bus-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  flex: 1;
+  min-height: 0;
+}
+
+.bus-traffic {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.bus-traffic-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: clamp(0.75rem, 0.72rem + 0.18vw, 0.9rem);
+  color: var(--muted);
+}
+
+.bus-traffic-row .line-pill {
+  flex: 0 0 auto;
+}
+
+.bus-traffic-row .line-alert-text {
+  font-weight: 600;
+}
+
+.bus-stations {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  align-content: start;
+  gap: 20px;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 10px;
+}
+
+.bus-station-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px 22px;
+  border-radius: 20px;
+  background: linear-gradient(155deg, rgba(10, 31, 69, 0.88), rgba(6, 20, 48, 0.82));
+  border: 1px solid rgba(96, 138, 212, 0.2);
+  box-shadow: 0 16px 32px rgba(4, 12, 32, 0.55);
+  backdrop-filter: blur(12px);
+  min-width: 0;
+  height: 100%;
+}
+
+.bus-station-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding-bottom: 8px;
+  border-bottom: 1px solid rgba(104, 146, 216, 0.16);
+}
+
+.bus-station-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.bus-station-title {
+  margin: 0;
+  font-size: clamp(1.05rem, 1rem + 0.35vw, 1.3rem);
+}
+
+.bus-station-summary {
+  margin: 0;
+  font-size: clamp(0.78rem, 0.72rem + 0.2vw, 0.95rem);
+  color: var(--muted);
+  transition: color 0.3s ease;
+  font-weight: 600;
+}
+
+.bus-station-summary.ok {
+  color: var(--success);
+}
+
+.bus-station-summary.alert {
+  color: var(--warning);
+}
+
+.bus-station-summary.unknown {
+  color: var(--danger);
+}
+
+.bus-station-status {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.bus-lines {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.bus-line-card {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px 18px;
+  border-radius: 16px;
+  background: linear-gradient(160deg, rgba(12, 38, 82, 0.85), rgba(8, 26, 60, 0.7));
+  border: 1px solid rgba(104, 144, 216, 0.16);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.bus-line-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.bus-line-header .line-pill {
+  flex: 0 0 auto;
+}
+
+.bus-line-traffic {
+  font-size: 0.82rem;
+  color: var(--muted);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+  font-weight: 600;
+}
+
+.bus-destinations {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.bus-destination-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: rgba(4, 18, 44, 0.6);
+  border: 1px solid rgba(96, 138, 212, 0.12);
+}
+
+.bus-destination-info {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  flex: 1;
+  min-width: 0;
 }
 
-/* RER */
-.rer-grid { display: grid; gap: 10px; grid-template-columns: 1fr 1fr; flex: 1; }
-.row { display: flex; align-items: center; gap: 12px; background: #fff; border: 2px solid #e6ecf7; border-left: 12px solid var(--rerA); border-radius: 12px; padding: 8px; }
-.dir { font-weight: 900; font-size: 15px; }
-.times { margin-left: auto; display: flex; gap: 6px; }
-
-/* Bus */
-.bus-list { display: grid; gap: 6px; flex: 1; }
-.bus-row { display: flex; align-items: center; gap: 8px; background: #fff; border: 2px solid #e6ecf7; border-radius: 10px; padding: 6px; }
-.bus-row.joinville { border-left: 10px solid var(--joinville); }
-.bus-row.hippodrome { border-left: 10px solid var(--hippodrome); }
-.bus-row.breuil { border-left: 10px solid var(--breuil); }
-.badge { display: inline-flex; align-items: center; justify-content: center; min-width: 30px; height: 30px; border-radius: 50%; background: #001826; color: #73c8ff; border: 2px solid #0e3d57; font-size: 12px; }
-.dest { font-weight: 900; font-size: 14px; flex: 1; }
-.sub { font-size: 10px; color: #6a7893; }
-.bus-times { display: flex; gap: 4px; }
-
-/* Vélib – style des stations */
-.velib-block {
-  background: #1a1d24;        /* gris sombre */
-  border: 1px solid #2c3344;  /* contour discret */
-  border-left: 6px solid #00aa55; /* bande verte pour rappeler Vélib' */
-  border-radius: 8px;
-  padding: 10px 12px;
-  margin-bottom: 12px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.4);
-  font-size: 14px;
-  line-height: 1.5;
+.destination-name {
+  font-weight: 700;
+  font-size: clamp(0.92rem, 0.86rem + 0.25vw, 1.1rem);
+  letter-spacing: 0.01em;
 }
 
-.velib-block strong {
-  font-size: 15px;
-  font-weight: 800;
-  color: #73ffba; /* vert fluo */
-  display: block;
-  margin-bottom: 4px;
+.status-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
 }
 
-#velib-update {
-  font-size: 12px;
-  color: #a9b1c3; /* gris clair */
-  margin-top: 8px;
-  text-align: right;
-  font-style: italic;
+.bus-times {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-end;
+  align-items: center;
 }
 
+.countdown-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.18);
+  color: var(--info);
+  font-weight: 700;
+  font-size: clamp(0.8rem, 0.75rem + 0.2vw, 0.95rem);
+  letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+}
 
-/* Courses Vincennes */
-.courses-list { display: grid; gap: 8px; flex: 1; grid-template-columns: 1fr 1fr; }
-.course-row { display: flex; align-items: center; gap: 8px; background: #fff; border: 2px solid #e6ecf7; border-left: 10px solid var(--vincennes); border-radius: 10px; padding: 6px; }
-.course-time { font-weight: 900; background: var(--vincennes); color: #fff; padding: 4px 8px; border-radius: 6px; font-size: 12px; }
-.course-info { flex: 1; }
-.course-name { font-weight: 900; font-size: 13px; }
-.course-details { font-size: 10px; color: #6a7893; }
-.course-prize { font-size: 11px; color: #2c5aa0; font-weight: 800; }
+.courses-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow-y: auto;
+  padding-right: 6px;
+}
 
-/* Info rotation */
-.info-rotating { position: relative; height: 100%; overflow: hidden; }
-.info-panel { position: absolute; inset: 0; opacity: 0; transition: opacity .5s ease; display: flex; flex-direction: column; justify-content: center; align-items: center; text-align: center; }
-.info-panel.active { opacity: 1; }
-.metric { display: flex; align-items: baseline; gap: 8px; }
-.metric .big { font-size: 36px; font-weight: 900; }
-.unit { font-size: 14px; color: #6a7893; }
-.info-desc { font-size: 11px; color: #6a7893; }
-
-/* Actualités */
-.news-content { position: relative; height: 100%; overflow: hidden; }
-.news-item { position: absolute; inset: 0; opacity: 0; transition: opacity .5s ease; padding: 12px; display: flex; flex-direction: column; justify-content: center; }
-.news-item.active { opacity: 1; }
-.news-title { font-weight: 900; font-size: 16px; margin-bottom: 6px; line-height: 1.3; }
-.news-text { font-size: 13px; line-height: 1.4; color: #ddd; }
-.news-meta { font-size: 10px; color: #999; margin-top: 6px; }
-
-/* Alerts & Errors */
-.error-msg { background: #2b0b0b; border: 2px solid #3a1010; color: #ffd6d6; padding: 8px 12px; border-radius: 8px; text-align: center; font-size: 12px; }
-.alert { position: absolute; left: 14px; right: 14px; bottom: 14px; background: linear-gradient(90deg,#2b0b0b,#1a0000); border: 2px solid #3a1010; color: #ffd6d6; padding: 8px 10px; border-radius: 10px; display: none; gap: 10px; align-items: center; font-weight: 800; font-size: 12px; }
-.alert .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--danger); }
-
-/* Correction de la grille principale */
-.dashboard-container, .grid {
+.course-row {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-  grid-gap: 20px;
-  padding: 20px;
-  box-sizing: border-box;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 2.1fr) minmax(0, 1.2fr) minmax(0, 0.9fr);
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: var(--panel-alt);
+  border: 1px solid rgba(255, 255, 255, 0.04);
 }
 
-/* Correction des blocs individuels */
-.block, .card {
-  position: relative; /* ✅ Pas d'absolute */
-  box-sizing: border-box;
-  margin-bottom: 0; /* ✅ Supprimer les marges qui causent les décalages */
-  min-height: 200px;
-  max-width: 100%;
+.course-time {
+  font-weight: 700;
+  color: var(--accent);
+  font-size: clamp(0.9rem, 0.85rem + 0.2vw, 1.05rem);
+}
+
+.course-info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.course-name {
+  font-weight: 600;
+  font-size: clamp(0.88rem, 0.82rem + 0.2vw, 1.05rem);
+}
+
+.course-details {
+  font-size: clamp(0.72rem, 0.68rem + 0.18vw, 0.86rem);
+  color: var(--muted);
+}
+
+.course-countdown {
+  justify-self: end;
+  font-weight: 600;
+  font-size: clamp(0.78rem, 0.72rem + 0.18vw, 0.9rem);
+  color: var(--info);
+  font-variant-numeric: tabular-nums;
+}
+
+.course-prize {
+  justify-self: end;
+  font-weight: 600;
+  font-size: clamp(0.78rem, 0.72rem + 0.18vw, 0.9rem);
+  color: var(--muted);
+}
+
+.road-body {
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
+.road-list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.road-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: rgba(12, 27, 48, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.road-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.road-axis {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.road-status {
+  font-weight: 700;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+}
+
+.road-status.fluid {
+  color: var(--success);
+}
+
+.road-status.dense {
+  color: var(--warning);
+}
+
+.road-status.jam {
+  color: var(--danger);
+}
+
+.road-status.unknown {
+  color: var(--muted);
+}
+
+.road-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 16px;
+  font-size: clamp(0.7rem, 0.66rem + 0.16vw, 0.84rem);
+  color: var(--muted);
+}
+
+.road-note {
+  margin: 0;
+  font-size: clamp(0.74rem, 0.7rem + 0.16vw, 0.88rem);
+  line-height: 1.4;
+  color: var(--muted);
+}
+
+.news-body {
+  position: relative;
+  min-height: 0;
   overflow: hidden;
 }
 
-/* Responsive mobile */
-@media (max-width: 768px) {
-  .dashboard-container, .grid {
-    grid-template-columns: 1fr;
-    padding: 10px;
-  }
-}
-/* Grille principale pour layout 3 colonnes */
-.dashboard-container {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr); /* 3 colonnes */
-  grid-gap: 20px;
-  padding: 20px;
-  background-color: #000; /* Fond noir comme sur l'image */
-  min-height: 100vh;
-  box-sizing: border-box;
+.news-content {
+  position: relative;
+  min-height: 0;
+  flex: 1;
 }
 
-/* Blocs individuels (pas de position absolute) */
-.block {
-  background-color: #fff;
-  border-radius: 8px;
-  padding: 15px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-  min-height: 150px;
+.news-item {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 0.4s ease, transform 0.4s ease;
   display: flex;
   flex-direction: column;
-  justify-content: flex-start;
-  overflow: hidden; /* Évite débordements */
+  gap: 12px;
 }
 
-/* Adaptation pour mobile (1 colonne) */
-@media (max-width: 768px) {
-  .dashboard-container {
-    grid-template-columns: 1fr;
+.news-item.active {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.news-title {
+  font-size: clamp(0.95rem, 0.9rem + 0.25vw, 1.2rem);
+  font-weight: 600;
+}
+
+.news-text {
+  font-size: clamp(0.82rem, 0.78rem + 0.18vw, 1rem);
+  line-height: 1.45;
+  color: var(--muted);
+}
+
+.news-meta {
+  font-size: clamp(0.7rem, 0.66rem + 0.16vw, 0.84rem);
+  color: var(--muted);
+}
+
+.news-counter {
+  font-size: clamp(0.76rem, 0.72rem + 0.18vw, 0.9rem);
+  color: var(--muted);
+}
+
+.velib-body {
+  gap: 14px;
+}
+
+.velib-card {
+  padding: 16px;
+  border-radius: 14px;
+  background: rgba(20, 184, 166, 0.08);
+  border: 1px solid rgba(20, 184, 166, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 92px;
+}
+
+.velib-card strong {
+  font-size: clamp(0.88rem, 0.82rem + 0.2vw, 1.05rem);
+  font-weight: 600;
+}
+
+.velib-card span {
+  font-size: clamp(0.78rem, 0.74rem + 0.18vw, 0.92rem);
+}
+
+.velib-update {
+  margin-top: 4px;
+  font-size: clamp(0.72rem, 0.68rem + 0.16vw, 0.86rem);
+  color: var(--muted);
+  text-align: right;
+}
+
+.empty-message {
+  font-size: clamp(0.78rem, 0.74rem + 0.18vw, 0.9rem);
+  color: var(--muted);
+}
+
+@keyframes weather-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.08);
   }
 }
 
-/* Sections spécifiques */
-#rer-section { grid-column: span 2; } /* RER sur 2 colonnes */
-#meteo-panel { grid-column: span 1; } /* Météo sur 1 colonne */
-#bus-joinville { background-color: #2E8B57; color: #fff; } /* Vert foncé */
-#bus-hippodrome { background-color: #4682B4; color: #fff; } /* Bleu */
-#bus-breuil { background-color: #DAA520; color: #fff; } /* Doré */
-#velib-section { grid-column: span 1; }
-#courses-section { grid-column: span 2; }
-#actualites-section { grid-column: span 3; } /* Actualités pleine largeur */
-
-/* Loader animé */
-.loader {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 8px;
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--muted);
-  height: 100%;
-  text-align: center;
+@keyframes weather-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
-.loader::after {
-  content: "";
-  width: 16px;
-  height: 16px;
-  border: 3px solid #ccc;
-  border-top: 3px solid var(--idfm-blue);
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
+@keyframes weather-drift {
+  0%,
+  100% {
+    transform: translateX(0px);
+  }
+  50% {
+    transform: translateX(6px);
+  }
 }
 
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+@keyframes weather-rain {
+  0% {
+    transform: translateY(0);
+    opacity: 0;
+  }
+  40% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(14px);
+    opacity: 0;
+  }
 }
 
-
-/* --- Trafic (perturbations, infos) --- */
-.traffic-container {
-  margin-top: 8px;
-  font-size: 13px;
+@keyframes weather-flash {
+  0%,
+  100% {
+    opacity: 0.3;
+  }
+  45% {
+    opacity: 1;
+  }
+  55% {
+    opacity: 0.2;
+  }
+  70% {
+    opacity: 1;
+  }
+  80% {
+    opacity: 0.3;
+  }
 }
 
-.traffic-alert {
-  background: #3a1010;
-  border: 1px solid #ff6b35;
-  color: #ffd6d6;
-  padding: 6px 10px;
-  border-radius: 6px;
-  margin-top: 4px;
-  font-weight: 600;
-  line-height: 1.4;
+@media (max-width: 1200px) {
+  .app-header {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-rows: auto auto;
+    align-items: center;
+    gap: 18px;
+    padding: 20px 24px;
+  }
+
+  .weather-widget {
+    justify-content: flex-start;
+  }
+
+  .dashboard-grid {
+    padding: 24px 26px 28px;
+    gap: 22px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-rows: auto minmax(0, 1fr) auto auto auto;
+    grid-template-areas:
+      "rer rer"
+      "bus bus"
+      "road news"
+      "courses news"
+      "velib velib";
+  }
+
+  .rer-body {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .rer-column:nth-child(3) {
+    display: none;
+  }
 }
 
-.traffic-ok {
-  background: #0e2f1c;
-  border: 1px solid #1f6c3a;
-  color: #c8ffd6;
-  padding: 6px 10px;
-  border-radius: 6px;
-  margin-top: 4px;
-  font-weight: 600;
+@media (orientation: portrait) and (min-width: 900px) {
+  .app-header {
+    padding: 20px 26px;
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+    grid-template-rows: auto auto;
+    grid-template-areas:
+      "branding header-right"
+      "weather header-right";
+    gap: 16px;
+  }
+
+  .branding {
+    grid-area: branding;
+  }
+
+  .weather-widget {
+    grid-area: weather;
+    justify-self: flex-start;
+  }
+
+  .header-right {
+    grid-area: header-right;
+    justify-self: end;
+    align-self: stretch;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 12px;
+  }
+
+  .dashboard-grid {
+    padding: 26px 28px 30px;
+    gap: 24px;
+    grid-template-columns: minmax(0, 1.2fr) minmax(0, 0.85fr);
+    grid-template-rows: auto minmax(0, 1fr) auto auto;
+    grid-template-areas:
+      "rer news"
+      "bus courses"
+      "bus road"
+      "bus velib";
+  }
+
+  .block {
+    border-radius: 18px;
+  }
+
+  .block-header {
+    padding: 16px 18px 14px;
+  }
+
+  .block-header h2 {
+    font-size: clamp(1rem, 0.95rem + 0.32vw, 1.25rem);
+  }
+
+  .block-sub {
+    font-size: clamp(0.74rem, 0.7rem + 0.18vw, 0.9rem);
+  }
+
+  .block-body {
+    padding: 16px 18px 18px;
+  }
+
+  .rer-body {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-auto-rows: minmax(0, 1fr);
+    gap: 16px;
+  }
+
+  .rer-column:nth-child(3) {
+    display: flex;
+    grid-column: 1 / -1;
+  }
+
+  .bus-stations {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 18px;
+    padding-right: 0;
+  }
+
+  .bus-station-card {
+    padding: 16px 18px;
+    gap: 12px;
+  }
+
+  .time-chip {
+    min-width: 64px;
+    padding: 8px 12px;
+  }
+
+  .time-chip-main {
+    font-size: clamp(0.95rem, 0.9rem + 0.4vw, 1.2rem);
+  }
+
+  .time-chip-sub {
+    font-size: clamp(0.6rem, 0.58rem + 0.12vw, 0.7rem);
+  }
 }
 
-.traffic-error {
-  background: #2b0b0b;
-  border: 1px solid #8b0000;
-  color: #ffd6d6;
-  padding: 6px 10px;
-  border-radius: 6px;
-  margin-top: 4px;
-  font-weight: 600;
-}
+@media (max-width: 960px) {
+  body {
+    overflow-y: auto;
+  }
 
-/* Loader de trafic */
-.loader {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 8px;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--muted);
-  padding: 8px;
-}
+  .app {
+    height: auto;
+  }
 
-.loader::after {
-  content: "";
-  width: 14px;
-  height: 14px;
-  border: 3px solid #ccc;
-  border-top: 3px solid var(--idfm-blue);
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-}
+  .app-header {
+    grid-template-columns: 1fr;
+    grid-template-rows: none;
+  }
 
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+  .dashboard-grid {
+    grid-template-columns: minmax(0, 1fr);
+    grid-auto-rows: auto;
+    padding: 18px 20px 24px;
+    gap: 16px;
+    overflow: visible;
+  }
+
+  .block-rer,
+  .block-road,
+  .block-news,
+  .block-velib,
+  .block-courses,
+  .block-bus {
+    grid-column: auto;
+    grid-row: auto;
+  }
+
+  .rer-body {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .rer-column:nth-child(3) {
+    display: flex;
+  }
+
+  .bus-stations {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 14px;
+    padding-right: 0;
+  }
+
+  .bus-station-card {
+    padding: 14px 16px;
+  }
+
+  .time-chip {
+    min-width: 56px;
+    padding: 8px 10px;
+  }
+
+  .time-chip-main {
+    font-size: clamp(0.88rem, 0.84rem + 0.28vw, 1.05rem);
+  }
+
+  .time-chip-sub {
+    font-size: clamp(0.56rem, 0.54rem + 0.1vw, 0.66rem);
+  }
 }


### PR DESCRIPTION
## Résumé
- aligne la grille principale sur la maquette fournie en faisant occuper à la section bus toute la colonne gauche sous le RER
- adapte le layout portrait (>=900 px) pour conserver le même empilement RER/bus vs actualités, courses, Sytadin et Vélib'

## Tests
- aucun test automatisé disponible

------
https://chatgpt.com/codex/tasks/task_e_68c99c84bf088333be0cd58ab0804fe6