### PR TITLE
Add utility tests and modularize helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.DS_Store

--- a/app.js
+++ b/app.js
@@ -1,3 +1,5 @@
+import { decodeEntities, cleanText, minutesFromISO } from "./utils.js";
+
 // === Constantes & endpoints ===
 const PROXY = "https://ratp-proxy.hippodrome-proxy42.workers.dev/?url=";
 const WEATHER_URL = "https://api.open-meteo.com/v1/forecast?latitude=48.835&longitude=2.45&current_weather=true";
@@ -26,11 +28,8 @@ let tickerData = { timeWeather: "", saint: "", horoscope: "", traffic: "" };
 let signIdx = 0;
 
 // === Utils ===
-function decodeEntities(str=""){return str.replace(/&nbsp;/gi," ").replace(/&amp;/gi,"&").replace(/&quot;/gi,'"').replace(/&#039;/gi,"'").replace(/&apos;/gi,"'").replace(/&lt;/gi,"<").replace(/&gt;/gi,">").trim();}
-function cleanText(str=""){return decodeEntities(str).replace(/<[^>]*>/g," ").replace(/[<>]/g," ").replace(/\s+/g," ").trim();}
 async function fetchJSON(url, timeout=12000){ try{ const c=new AbortController(); const t=setTimeout(()=>c.abort(),timeout); const r=await fetch(url,{signal:c.signal, cache:"no-store"}); clearTimeout(t); if(!r.ok) throw new Error(`HTTP ${r.status}`); return await r.json(); } catch(e){ console.error("fetchJSON",url,e.message); return null; } }
 async function fetchText(url, timeout=12000){ try{ const c=new AbortController(); const t=setTimeout(()=>c.abort(),timeout); const r=await fetch(url,{signal:c.signal, cache:"no-store"}); clearTimeout(t); if(!r.ok) throw new Error(`HTTP ${r.status}`); return await r.text(); } catch(e){ console.error("fetchText",url,e.message); return ""; } }
-function minutesFromISO(iso){ if(!iso) return null; return Math.max(0, Math.round((new Date(iso).getTime()-Date.now())/60000)); }
 function setClock(){ const el=document.getElementById("clock"); if(el) el.textContent=new Date().toLocaleTimeString("fr-FR",{hour:"2-digit",minute:"2-digit"}); }
 function setLastUpdate(){ const el=document.getElementById("lastUpdate"); if(el) el.textContent=`Maj ${new Date().toLocaleTimeString("fr-FR",{hour:"2-digit",minute:"2-digit"})}`; }
 

--- a/index.html
+++ b/index.html
@@ -116,6 +116,6 @@
 
   </div>
 
-  <script src="app.js"></script>
+  <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "start": "node server.js",
-    "dev": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "test": "node --test"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { cleanText, decodeEntities, minutesFromISO } from '../utils.js';
+
+test('decodeEntities remplace les entités HTML courantes', () => {
+  const input = 'Bonjour &amp; bienvenue &lt;strong&gt;à tous&lt;/strong&gt; !';
+  const output = decodeEntities(input);
+  assert.equal(output, 'Bonjour & bienvenue <strong>à tous</strong> !');
+});
+
+test('cleanText supprime les balises et espaces multiples', () => {
+  const input = '\n<p> Hello &amp; <strong>world</strong> ! </p>\n';
+  const output = cleanText(input);
+  assert.equal(output, 'Hello & world !');
+});
+
+test('minutesFromISO calcule un temps positif arrondi à la minute la plus proche', () => {
+  const originalNow = Date.now;
+  const base = new Date('2024-01-01T12:00:00Z');
+  Date.now = () => base.getTime();
+
+  try {
+    const fiveMinutesLater = new Date(base.getTime() + 5 * 60 * 1000).toISOString();
+    assert.equal(minutesFromISO(fiveMinutesLater), 5);
+
+    const thirtySecondsLater = new Date(base.getTime() + 30 * 1000).toISOString();
+    assert.equal(minutesFromISO(thirtySecondsLater), 1);
+
+    const pastDate = new Date(base.getTime() - 60 * 1000).toISOString();
+    assert.equal(minutesFromISO(pastDate), 0);
+
+    assert.equal(minutesFromISO(null), null);
+  } finally {
+    Date.now = originalNow;
+  }
+});

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,23 @@
+export function decodeEntities(str = "") {
+  return str
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#039;/gi, "'")
+    .replace(/&apos;/gi, "'")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">").trim();
+}
+
+export function cleanText(str = "") {
+  return decodeEntities(str)
+    .replace(/<[^>]*>/g, " ")
+    .replace(/[<>]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function minutesFromISO(iso) {
+  if (!iso) return null;
+  return Math.max(0, Math.round((new Date(iso).getTime() - Date.now()) / 60000));
+}


### PR DESCRIPTION
## Summary
- extract text utility helpers into a dedicated module for reuse
- switch the client script to an ES module to consume the shared helpers
- add unit tests covering entity decoding, HTML cleaning and minute calculations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68dda307eb8c83339a743e03070e1de0