### PR TITLE
Affichage des bus par destination et statut

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/app.js
+++ b/app.js
@@ -52,6 +52,33 @@ function minutesFromISO(iso){ if(!iso) return null; return Math.max(0, Math.roun
 function setClock(){ const el=document.getElementById("clock"); if(el) el.textContent=new Date().toLocaleTimeString("fr-FR",{hour:"2-digit",minute:"2-digit"}); }
 function setLastUpdate(){ const el=document.getElementById("lastUpdate"); if(el) el.textContent=`Maj ${new Date().toLocaleTimeString("fr-FR",{hour:"2-digit",minute:"2-digit"})}`; }
 
+function flattenStatuses(...values){
+  const out=[];
+  const pushVal=(val)=>{
+    if(val==null) return;
+    if(Array.isArray(val)){
+      val.forEach(pushVal);
+    }else if(typeof val==="object" && "value" in val){
+      pushVal(val.value);
+    }else{
+      out.push(String(val));
+    }
+  };
+  values.forEach(pushVal);
+  return out;
+}
+
+function statusLabelFromCodes(codes){
+  if(!codes?.length) return null;
+  const normalized=codes.map(c=>c.toLowerCase());
+  if(normalized.some(c=>/service.?terminated|completed/.test(c))) return "Service terminé";
+  if(normalized.some(c=>/cancel/.test(c))) return "Course annulée";
+  if(normalized.some(c=>/not.?yet.?operating/.test(c))) return "Pas encore en service";
+  if(normalized.some(c=>/no.?report/.test(c))) return "Pas d'information";
+  if(normalized.some(c=>/arrived|departed/.test(c))) return "Passage effectué";
+  return null;
+}
+
 // === Référentiel lignes (couleurs IDFM) ===
 function normaliseColor(hex){ if(!hex) return null; const c=hex.toString().trim().replace(/^#/,""); return /^[0-9a-fA-F]{6}$/.test(c)?`#${c}`:null; }
 function fallbackLineMeta(id){ return { id, code:id, color:"#2450a4", textColor:"#fff" }; }
@@ -73,7 +100,26 @@ function parseStop(data){
     const lineRef=mv.LineRef?.value||mv.LineRef||""; const lineId=(lineRef.match(/C\d{5}/)||[null])[0];
     const destDisplay=cleanText(call.DestinationDisplay?.[0]?.value||"");
     const expected=call.ExpectedDepartureTime||call.ExpectedArrivalTime||null;
-    return { lineId, dest: destDisplay, minutes: minutesFromISO(expected) };
+    const originName=cleanText(mv.OriginName?.[0]?.value||mv.OriginName?.value||"");
+    const distanceText=cleanText(call.Extensions?.Distances?.PresentableDistance||"");
+    const statusCodes=flattenStatuses(
+      call.DepartureStatus,
+      call.ArrivalStatus,
+      mv.ProgressStatus,
+      call.Extensions?.CallStatus?.Status,
+      call.Extensions?.CallStatus?.Statuses,
+      call.Extensions?.StopCallStatus?.Status,
+      call.Extensions?.StopCallStatus?.Statuses
+    );
+    return {
+      lineId,
+      dest: destDisplay || "Destination inconnue",
+      origin: originName,
+      minutes: minutesFromISO(expected),
+      distance: distanceText,
+      statusCodes,
+      statusLabel: statusLabelFromCodes(statusCodes)
+    };
   });
 }
 
@@ -112,25 +158,66 @@ async function renderBusByStop() {
     block.className = "bus-stop-block";
     block.innerHTML = `<h3 class="bus-stop-title">🚏 ${stop.name}</h3>`;
 
-    const byLine = {};
+    const byDestination = new Map();
     visits.forEach(v => {
-      if (!byLine[v.lineId]) byLine[v.lineId] = [];
-      byLine[v.lineId].push(v);
+      const key = v.dest || "Destination inconnue";
+      if (!byDestination.has(key)) byDestination.set(key, []);
+      byDestination.get(key).push(v);
     });
 
-    for (const [lineId, rows] of Object.entries(byLine)) {
-      const meta = await fetchLineMetadata(lineId);
-      const lineHeader = document.createElement("div");
-      lineHeader.className = "bus-line-header";
-      lineHeader.innerHTML = `<span class="line-pill" style="background:${meta.color};color:${meta.textColor}">${meta.code}</span>`;
-      block.appendChild(lineHeader);
+    for (const [destination, rows] of byDestination.entries()) {
+      const destGroup = document.createElement("div");
+      destGroup.className = "bus-destination-group";
+      const title = document.createElement("div");
+      title.className = "bus-destination-title";
+      title.textContent = `➡️ ${destination}`;
+      destGroup.appendChild(title);
 
-      rows.slice(0, 4).forEach(r => {
+      const orderedRows = rows.slice().sort((a, b) => (a.minutes ?? Infinity) - (b.minutes ?? Infinity));
+      for (const r of orderedRows) {
+        const meta = await fetchLineMetadata(r.lineId);
         const row = document.createElement("div");
-        row.className = "row";
-        row.innerHTML = `<div class="dest">${r.dest}</div><div class="times">${r.minutes != null ? r.minutes + " min" : "--"}</div>`;
-        block.appendChild(row);
-      });
+        row.className = "row bus-row";
+        if (r.statusCodes?.some(code => /service.?terminated|completed/i.test(code))) {
+          row.classList.add("bus-row-ended");
+        }
+
+        const pill = document.createElement("span");
+        pill.className = "line-pill";
+        pill.style.background = meta.color;
+        pill.style.color = meta.textColor;
+        pill.textContent = meta.code;
+        row.appendChild(pill);
+
+        const info = document.createElement("div");
+        info.className = "dest";
+        info.textContent = r.origin ? `Depuis ${r.origin}` : destination;
+        row.appendChild(info);
+
+        const time = document.createElement("div");
+        time.className = "times";
+        if (r.statusLabel) {
+          const statusSpan = document.createElement("span");
+          statusSpan.className = "status-tag";
+          statusSpan.textContent = r.statusLabel;
+          time.appendChild(statusSpan);
+        }
+        if (Number.isFinite(r.minutes)) {
+          const minuteSpan = document.createElement("span");
+          minuteSpan.textContent = `${r.minutes} min`;
+          time.appendChild(minuteSpan);
+        } else if (r.distance) {
+          const distanceSpan = document.createElement("span");
+          distanceSpan.textContent = r.distance;
+          time.appendChild(distanceSpan);
+        }
+        if (!time.childNodes.length) time.textContent = "--";
+        row.appendChild(time);
+
+        destGroup.appendChild(row);
+      }
+
+      block.appendChild(destGroup);
     }
     container.appendChild(block);
   }

--- a/app.js
+++ b/app.js
@@ -141,22 +141,34 @@ async function renderRer(){
 // === BUS par arrêt ===
 async function renderBusByStop() {
   const stops = [
+    { id: STOP_IDS.JOINVILLE, name: "Joinville-le-Pont RER" },
     { id: STOP_IDS.HIPPODROME, name: "Hippodrome de Vincennes" },
-    { id: STOP_IDS.BREUIL, name: "École du Breuil" },
-    { id: STOP_IDS.JOINVILLE, name: "Joinville-le-Pont" }
+    { id: STOP_IDS.BREUIL, name: "École du Breuil" }
   ];
 
   const container = document.getElementById("bus-blocks");
   container.innerHTML = "";
 
   for (const stop of stops) {
-    const data = await fetchJSON(PROXY + encodeURIComponent(`https://prim.iledefrance-mobilites.fr/marketplace/stop-monitoring?MonitoringRef=${stop.id}`));
-    const visits = parseStop(data);
-    if (!visits.length) continue;
-
     const block = document.createElement("div");
     block.className = "bus-stop-block";
     block.innerHTML = `<h3 class="bus-stop-title">🚏 ${stop.name}</h3>`;
+
+    const content = document.createElement("div");
+    content.className = "bus-stop-content";
+    block.appendChild(content);
+    container.appendChild(block);
+
+    const data = await fetchJSON(PROXY + encodeURIComponent(`https://prim.iledefrance-mobilites.fr/marketplace/stop-monitoring?MonitoringRef=${stop.id}`));
+    const visits = parseStop(data);
+
+    if (!visits.length) {
+      const empty = document.createElement("div");
+      empty.className = "bus-empty";
+      empty.textContent = "Aucun passage affiché";
+      content.appendChild(empty);
+      continue;
+    }
 
     const byDestination = new Map();
     visits.forEach(v => {
@@ -165,7 +177,9 @@ async function renderBusByStop() {
       byDestination.get(key).push(v);
     });
 
-    for (const [destination, rows] of byDestination.entries()) {
+    const sortedDestinations = [...byDestination.entries()].sort((a, b) => a[0].localeCompare(b[0], "fr", { sensitivity: "base" }));
+
+    for (const [destination, rows] of sortedDestinations) {
       const destGroup = document.createElement("div");
       destGroup.className = "bus-destination-group";
       const title = document.createElement("div");
@@ -217,9 +231,8 @@ async function renderBusByStop() {
         destGroup.appendChild(row);
       }
 
-      block.appendChild(destGroup);
+      content.appendChild(destGroup);
     }
-    container.appendChild(block);
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -49,15 +49,19 @@ body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sa
 .times{display:flex;gap:6px}
 .time-box{background:var(--time-box-bg);color:var(--time-box-fg);font-weight:900;font-variant-numeric:tabular-nums;padding:4px 10px;border-radius:6px;min-width:40px;text-align:center}
 
-.bus-stop-block{padding:4px 0}
-.bus-stop-block + .bus-stop-block{border-top:1px solid #e5e7eb;margin-top:12px;padding-top:12px}
-.bus-stop-title{margin:0 0 4px;font-size:1rem;color:var(--blue)}
-.bus-destination-group{margin-bottom:10px}
-.bus-destination-title{font-size:.78rem;color:var(--muted);font-weight:700;text-transform:uppercase;letter-spacing:.02em;margin:8px 0 4px}
+#bus-blocks{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:14px;margin-top:6px}
+#bus-blocks .row{border-bottom:none}
+.bus-stop-block{background:#f8fafc;border-radius:12px;padding:10px;box-shadow:var(--shadow);display:flex;flex-direction:column;min-height:180px}
+.bus-stop-title{margin:0 0 8px;font-size:1rem;color:var(--blue)}
+.bus-stop-content{display:flex;flex-direction:column;gap:10px;flex:1}
+.bus-destination-group{padding:8px;border-radius:10px;background:#fff;box-shadow:inset 0 0 0 1px rgba(15,23,42,.04)}
+.bus-destination-title{font-size:.78rem;color:var(--muted);font-weight:700;text-transform:uppercase;letter-spacing:.02em;margin:0 0 6px}
+.bus-row{padding:4px 0}
 .bus-row .dest{color:var(--ink);font-weight:600}
 .bus-row .times{align-items:center;flex-wrap:wrap}
 .bus-row-ended{opacity:.6}
 .status-tag{background:#fee2e2;color:#991b1b;font-weight:700;border-radius:999px;padding:2px 8px;font-size:.72rem;text-transform:uppercase;letter-spacing:.03em}
+.bus-empty{flex:1;display:flex;align-items:center;justify-content:center;border:1px dashed rgba(148,163,184,.6);border-radius:10px;padding:14px;color:var(--muted);font-weight:600;text-align:center}
 
 /* Best route */
 .best-route{background:#0f172a;color:#fff;border-radius:10px;padding:10px}

--- a/styles.css
+++ b/styles.css
@@ -49,6 +49,16 @@ body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sa
 .times{display:flex;gap:6px}
 .time-box{background:var(--time-box-bg);color:var(--time-box-fg);font-weight:900;font-variant-numeric:tabular-nums;padding:4px 10px;border-radius:6px;min-width:40px;text-align:center}
 
+.bus-stop-block{padding:4px 0}
+.bus-stop-block + .bus-stop-block{border-top:1px solid #e5e7eb;margin-top:12px;padding-top:12px}
+.bus-stop-title{margin:0 0 4px;font-size:1rem;color:var(--blue)}
+.bus-destination-group{margin-bottom:10px}
+.bus-destination-title{font-size:.78rem;color:var(--muted);font-weight:700;text-transform:uppercase;letter-spacing:.02em;margin:8px 0 4px}
+.bus-row .dest{color:var(--ink);font-weight:600}
+.bus-row .times{align-items:center;flex-wrap:wrap}
+.bus-row-ended{opacity:.6}
+.status-tag{background:#fee2e2;color:#991b1b;font-weight:700;border-radius:999px;padding:2px 8px;font-size:.72rem;text-transform:uppercase;letter-spacing:.03em}
+
 /* Best route */
 .best-route{background:#0f172a;color:#fff;border-radius:10px;padding:10px}
 .best-option{display:flex;gap:10px;align-items:center}


### PR DESCRIPTION
## Résumé
- regrouper les passages de bus par destination et afficher tous les services, y compris ceux terminés ou annulés
- enrichir l'analyse des données SIRI pour exposer l'origine, les distances et les statuts lisibles
- améliorer le style de la section bus et ignorer le dossier node_modules côté dépôt

## Tests
- Aucun test automatisé disponible

------
https://chatgpt.com/codex/tasks/task_e_68de243ff39c8333a2c29a586e6fea3a