### PR TITLE
Affinage de la carte RER A

### DIFF
--- a/app.js
+++ b/app.js
@@ -125,16 +125,128 @@ function parseStop(data){
 
 // === RER ===
 async function renderRer(){
+  const container=document.getElementById("rer-body");
+  if(!container) return;
+
+  container.innerHTML="";
+
+  const card=document.createElement("div");
+  card.className="rer-card";
+  card.innerHTML=`
+    <div class="rer-card-header">
+      <div class="rer-card-header-main">
+        <span class="line-pill rer-a" aria-hidden="true">A</span>
+        <div class="rer-card-header-text">
+          <div class="rer-card-title">RER A</div>
+          <div class="rer-card-subtitle">Joinville-le-Pont → Paris</div>
+        </div>
+      </div>
+      <div class="rer-card-header-hint">Prochains trains vers Paris</div>
+    </div>
+  `;
+
+  const body=document.createElement("div");
+  body.className="rer-card-body";
+  body.innerHTML=`<div class="rer-empty">Chargement des circulations…</div>`;
+  card.appendChild(body);
+  container.appendChild(card);
+
   const data=await fetchJSON(PROXY+encodeURIComponent(`https://prim.iledefrance-mobilites.fr/marketplace/stop-monitoring?MonitoringRef=${STOP_IDS.RER_A}`));
-  const visits=parseStop(data).filter(v=>/paris|nation|châtelet|haussmann/i.test(v.dest||"")).slice(0,6);
-  const cont=document.getElementById("rer-body");
-  cont.innerHTML="";
+  const visits=parseStop(data)
+    .filter(v=>/paris|nation|châtelet|haussmann/i.test(v.dest||""))
+    .slice(0,6);
+
+  body.innerHTML="";
+
+  if(!visits.length){
+    const empty=document.createElement("div");
+    empty.className="rer-empty";
+    empty.innerHTML="<strong>Aucune desserte vers Paris pour le moment.</strong><br><span class=\"rer-empty-hint\">Prochaine mise à jour dans quelques secondes.</span>";
+    body.appendChild(empty);
+    return;
+  }
+
+  const columns=document.createElement("div");
+  columns.className="rer-columns";
+  columns.innerHTML=`
+    <span class="rer-col rer-col-wait">Attente</span>
+    <span class="rer-col rer-col-origin">Origine</span>
+    <span class="rer-col rer-col-info">Infos</span>
+  `;
+  body.appendChild(columns);
+
+  const groupsMap=new Map();
   visits.forEach(v=>{
-    const row=document.createElement("div"); row.className="row";
-    const pill=document.createElement("span"); pill.className="line-pill rer-a"; pill.textContent="A"; row.appendChild(pill);
-    const dest=document.createElement("div"); dest.className="dest"; dest.textContent=v.dest; row.appendChild(dest);
-    const time=document.createElement("div"); time.className="times"; time.textContent=(v.minutes!=null?`${v.minutes} min`:"--"); row.appendChild(time);
-    cont.appendChild(row);
+    const key=v.dest||"Destination inconnue";
+    if(!groupsMap.has(key)) groupsMap.set(key,[]);
+    groupsMap.get(key).push(v);
+  });
+
+  const groups=Array.from(groupsMap.entries()).map(([dest, list])=>{
+    const sorted=list.slice().sort((a,b)=>{
+      const aMin=a.minutes!=null?a.minutes:Number.POSITIVE_INFINITY;
+      const bMin=b.minutes!=null?b.minutes:Number.POSITIVE_INFINITY;
+      return aMin-bMin;
+    });
+    return { dest, visits: sorted };
+  }).sort((a,b)=>{
+    const aMin=a.visits[0]?.minutes!=null?a.visits[0].minutes:Number.POSITIVE_INFINITY;
+    const bMin=b.visits[0]?.minutes!=null?b.visits[0].minutes:Number.POSITIVE_INFINITY;
+    return aMin-bMin;
+  });
+
+  groups.forEach(group=>{
+    const groupEl=document.createElement("div");
+    groupEl.className="rer-destination-group";
+
+    const title=document.createElement("div");
+    title.className="rer-destination-title";
+    title.innerHTML=`
+      <span class="rer-destination-name">${group.dest}</span>
+      <span class="rer-destination-count">${group.visits.length} circulation${group.visits.length>1?"s":""}</span>
+    `;
+    groupEl.appendChild(title);
+
+    const list=document.createElement("div");
+    list.className="rer-train-list";
+
+    group.visits.forEach(visit=>{
+      const row=document.createElement("div");
+      row.className="rer-train-row";
+
+      const waitCell=document.createElement("div");
+      waitCell.className="rer-train-wait";
+      const waitPill=document.createElement("span");
+      waitPill.className="rer-wait-pill";
+      waitPill.textContent=visit.minutes!=null?visit.minutes:"--";
+      waitCell.appendChild(waitPill);
+      if(visit.minutes!=null){
+        const waitLabel=document.createElement("span");
+        waitLabel.className="rer-wait-label";
+        waitLabel.textContent="min";
+        waitCell.appendChild(waitLabel);
+      }
+      row.appendChild(waitCell);
+
+      const info=document.createElement("div");
+      info.className="rer-train-info";
+      const origin=document.createElement("div");
+      origin.className="rer-train-origin";
+      origin.textContent=visit.origin||"Origine non communiquée";
+      info.appendChild(origin);
+      row.appendChild(info);
+
+      const meta=document.createElement("div");
+      meta.className="rer-train-meta";
+      const metaParts=[visit.statusLabel, visit.distance].filter(Boolean);
+      meta.textContent=metaParts.join(" · ");
+      row.appendChild(meta);
+
+      list.appendChild(row);
+    });
+
+    groupEl.appendChild(list);
+    body.appendChild(groupEl);
   });
 }
 

--- a/styles.css
+++ b/styles.css
@@ -49,6 +49,42 @@ body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sa
 .times{display:flex;gap:6px}
 .time-box{background:var(--time-box-bg);color:var(--time-box-fg);font-weight:900;font-variant-numeric:tabular-nums;padding:4px 10px;border-radius:6px;min-width:40px;text-align:center}
 
+#rer-body{display:flex;justify-content:center}
+.rer-card{width:100%;max-width:400px;border-radius:20px;box-shadow:var(--shadow);overflow:hidden;border:1px solid rgba(15,23,42,.08);background:linear-gradient(150deg,rgba(0,160,226,.16),rgba(255,255,255,.92));display:flex;flex-direction:column}
+.rer-card-header{background:linear-gradient(130deg,#0a2f7f,#00a0e2);color:#fff;padding:16px 20px;display:flex;flex-direction:column;gap:10px}
+.rer-card-header-main{display:flex;align-items:center;gap:14px}
+.rer-card-header-text{display:flex;flex-direction:column;gap:2px}
+.rer-card-header .line-pill{margin-right:0;min-width:44px;height:34px;font-size:1.05rem;background:var(--idfm-red)}
+.rer-card-title{font-size:1.05rem;font-weight:800;letter-spacing:.01em}
+.rer-card-subtitle{font-size:.85rem;opacity:.9}
+.rer-card-header-hint{font-size:.75rem;letter-spacing:.08em;text-transform:uppercase;opacity:.8;font-weight:700}
+.rer-card-body{padding:18px 20px 20px;display:flex;flex-direction:column;gap:16px}
+.rer-columns{display:grid;grid-template-columns:84px 1fr 112px;font-size:.72rem;font-weight:700;color:var(--muted);text-transform:uppercase;letter-spacing:.12em;padding:0 4px}
+.rer-col{display:flex;align-items:center}
+.rer-col-info{justify-content:flex-end}
+.rer-destination-group{background:#fff;border-radius:16px;padding:14px 16px;box-shadow:inset 0 0 0 1px rgba(15,23,42,.05);display:flex;flex-direction:column;gap:12px}
+.rer-destination-title{display:flex;align-items:center;justify-content:space-between;font-size:.8rem;font-weight:700;color:var(--blue);text-transform:uppercase;letter-spacing:.08em}
+.rer-destination-count{font-size:.7rem;color:var(--muted);font-weight:600}
+.rer-train-list{display:flex;flex-direction:column;gap:10px}
+.rer-train-row{display:grid;grid-template-columns:84px 1fr 112px;gap:14px;align-items:center}
+.rer-train-wait{display:flex;align-items:center;gap:6px}
+.rer-wait-pill{background:var(--idfm-red);color:#fff;font-weight:800;border-radius:999px;padding:4px 14px;min-width:48px;text-align:center;font-variant-numeric:tabular-nums;letter-spacing:.04em;box-shadow:0 2px 6px rgba(226,0,26,.28)}
+.rer-wait-label{font-size:.72rem;color:var(--muted);font-weight:700;text-transform:uppercase;letter-spacing:.14em}
+.rer-train-info{display:flex;flex-direction:column;gap:2px}
+.rer-train-origin{font-weight:600;color:var(--ink)}
+.rer-train-meta{font-size:.78rem;color:var(--muted);text-align:right}
+.rer-empty{background:rgba(255,255,255,.9);border-radius:16px;padding:20px;text-align:center;color:var(--muted);display:flex;flex-direction:column;gap:6px;box-shadow:inset 0 0 0 1px rgba(148,163,184,.2)}
+.rer-empty strong{font-size:.92rem;color:var(--ink)}
+.rer-empty-hint{font-size:.75rem}
+
+@media(max-width:720px){
+  #rer-body{justify-content:stretch}
+  .rer-card{max-width:none}
+  .rer-columns{grid-template-columns:74px 1fr 90px}
+  .rer-train-row{grid-template-columns:1fr;gap:6px}
+  .rer-train-meta{text-align:left}
+}
+
 #bus-blocks{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:14px;margin-top:6px}
 #bus-blocks .row{border-bottom:none}
 .bus-stop-block{background:#f8fafc;border-radius:12px;padding:10px;box-shadow:var(--shadow);display:flex;flex-direction:column;min-height:180px}


### PR DESCRIPTION
## Résumé
- Harmonisation de l'en-tête et du fond de la carte RER avec la charte IDFM et ajout d'un rappel sur les trains vers Paris.
- Ajout d'une ligne d'entête de colonnes et d'un compteur par destination pour structurer les circulations.
- Amélioration du message de repli pour guider l'utilisateur lorsqu'aucune desserte n'est disponible.

## Tests
- N/A (mise à jour front-end uniquement)


------
https://chatgpt.com/codex/tasks/task_e_68dea150d3c48333958f557775889888